### PR TITLE
feat: US-020 - CJK word grouping - character-width-based tolerance

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -9,5 +9,5 @@ pub mod text;
 pub mod words;
 
 pub use geometry::BBox;
-pub use text::Char;
+pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber-core/src/text.rs
+++ b/crates/pdfplumber-core/src/text.rs
@@ -13,6 +13,55 @@ pub struct Char {
     pub size: f64,
 }
 
+/// Text flow direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TextDirection {
+    /// Left-to-right (default for Latin, CJK horizontal).
+    #[default]
+    Ltr,
+    /// Right-to-left (Arabic, Hebrew).
+    Rtl,
+    /// Top-to-bottom (CJK vertical writing).
+    Ttb,
+    /// Bottom-to-top.
+    Btt,
+}
+
+/// Returns `true` if the character is a CJK ideograph, syllable, or kana.
+///
+/// Covers the main Unicode blocks used by Chinese, Japanese, and Korean text:
+/// - CJK Unified Ideographs (U+4E00–U+9FFF)
+/// - CJK Extension A (U+3400–U+4DBF)
+/// - CJK Extension B (U+20000–U+2A6DF)
+/// - CJK Compatibility Ideographs (U+F900–U+FAFF)
+/// - Hiragana (U+3040–U+309F)
+/// - Katakana (U+30A0–U+30FF)
+/// - Hangul Syllables (U+AC00–U+D7AF)
+/// - Hangul Jamo (U+1100–U+11FF)
+/// - Bopomofo (U+3100–U+312F)
+/// - CJK Radicals Supplement (U+2E80–U+2EFF)
+/// - Kangxi Radicals (U+2F00–U+2FDF)
+pub fn is_cjk(c: char) -> bool {
+    matches!(c,
+        '\u{4E00}'..='\u{9FFF}'   // CJK Unified Ideographs
+        | '\u{3400}'..='\u{4DBF}' // CJK Extension A
+        | '\u{F900}'..='\u{FAFF}' // CJK Compatibility Ideographs
+        | '\u{3040}'..='\u{309F}' // Hiragana
+        | '\u{30A0}'..='\u{30FF}' // Katakana
+        | '\u{AC00}'..='\u{D7AF}' // Hangul Syllables
+        | '\u{1100}'..='\u{11FF}' // Hangul Jamo
+        | '\u{3100}'..='\u{312F}' // Bopomofo
+        | '\u{2E80}'..='\u{2EFF}' // CJK Radicals Supplement
+        | '\u{2F00}'..='\u{2FDF}' // Kangxi Radicals
+        | '\u{20000}'..='\u{2A6DF}' // CJK Extension B
+    )
+}
+
+/// Returns `true` if the first character of the text is CJK.
+pub fn is_cjk_text(text: &str) -> bool {
+    text.chars().next().is_some_and(is_cjk)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -29,5 +78,52 @@ mod tests {
         assert_eq!(ch.bbox.x0, 10.0);
         assert_eq!(ch.fontname, "Helvetica");
         assert_eq!(ch.size, 12.0);
+    }
+
+    #[test]
+    fn test_text_direction_default() {
+        let dir = TextDirection::default();
+        assert_eq!(dir, TextDirection::Ltr);
+    }
+
+    #[test]
+    fn test_is_cjk_chinese() {
+        assert!(is_cjk('中'));
+        assert!(is_cjk('国'));
+        assert!(is_cjk('人'));
+    }
+
+    #[test]
+    fn test_is_cjk_japanese_hiragana() {
+        assert!(is_cjk('あ'));
+        assert!(is_cjk('い'));
+    }
+
+    #[test]
+    fn test_is_cjk_japanese_katakana() {
+        assert!(is_cjk('ア'));
+        assert!(is_cjk('イ'));
+    }
+
+    #[test]
+    fn test_is_cjk_korean() {
+        assert!(is_cjk('한'));
+        assert!(is_cjk('글'));
+    }
+
+    #[test]
+    fn test_is_cjk_latin() {
+        assert!(!is_cjk('A'));
+        assert!(!is_cjk('z'));
+        assert!(!is_cjk('0'));
+        assert!(!is_cjk(' '));
+    }
+
+    #[test]
+    fn test_is_cjk_text() {
+        assert!(is_cjk_text("中文"));
+        assert!(is_cjk_text("한글"));
+        assert!(!is_cjk_text("Hello"));
+        assert!(!is_cjk_text(""));
     }
 }

--- a/crates/pdfplumber-core/src/words.rs
+++ b/crates/pdfplumber-core/src/words.rs
@@ -1,5 +1,5 @@
 use crate::geometry::BBox;
-use crate::text::Char;
+use crate::text::{Char, TextDirection, is_cjk_text};
 
 /// Options for word extraction, matching pdfplumber defaults.
 #[derive(Debug, Clone)]
@@ -12,6 +12,8 @@ pub struct WordOptions {
     pub keep_blank_chars: bool,
     /// If true, use the text flow order from the PDF content stream instead of spatial ordering.
     pub use_text_flow: bool,
+    /// Text direction for grouping characters.
+    pub text_direction: TextDirection,
 }
 
 impl Default for WordOptions {
@@ -21,6 +23,7 @@ impl Default for WordOptions {
             y_tolerance: 3.0,
             keep_blank_chars: false,
             use_text_flow: false,
+            text_direction: TextDirection::default(),
         }
     }
 }
@@ -45,10 +48,13 @@ impl WordExtractor {
     /// Characters are grouped into words based on spatial proximity:
     /// - Characters within `x_tolerance` horizontally and `y_tolerance` vertically
     ///   are grouped together.
+    /// - For CJK characters, character width (or height for vertical text) is used
+    ///   as the tolerance instead of the fixed `x_tolerance`/`y_tolerance`.
     /// - By default, whitespace characters split words. Set `keep_blank_chars`
     ///   to include them.
-    /// - By default, characters are sorted spatially (top-to-bottom, left-to-right).
-    ///   Set `use_text_flow` to preserve PDF content stream order.
+    /// - By default, characters are sorted spatially. Set `use_text_flow` to
+    ///   preserve PDF content stream order.
+    /// - `text_direction` controls sorting and gap logic for vertical text.
     pub fn extract(chars: &[Char], options: &WordOptions) -> Vec<Word> {
         if chars.is_empty() {
             return Vec::new();
@@ -56,14 +62,44 @@ impl WordExtractor {
 
         let mut sorted_chars: Vec<&Char> = chars.iter().collect();
         if !options.use_text_flow {
-            sorted_chars.sort_by(|a, b| {
-                a.bbox
-                    .top
-                    .partial_cmp(&b.bbox.top)
-                    .unwrap()
-                    .then(a.bbox.x0.partial_cmp(&b.bbox.x0).unwrap())
-            });
+            match options.text_direction {
+                TextDirection::Ttb => {
+                    // Vertical: columns right-to-left, top-to-bottom within column
+                    sorted_chars.sort_by(|a, b| {
+                        b.bbox
+                            .x0
+                            .partial_cmp(&a.bbox.x0)
+                            .unwrap()
+                            .then(a.bbox.top.partial_cmp(&b.bbox.top).unwrap())
+                    });
+                }
+                TextDirection::Btt => {
+                    // Vertical bottom-to-top: columns right-to-left, bottom-to-top
+                    sorted_chars.sort_by(|a, b| {
+                        b.bbox
+                            .x0
+                            .partial_cmp(&a.bbox.x0)
+                            .unwrap()
+                            .then(b.bbox.bottom.partial_cmp(&a.bbox.bottom).unwrap())
+                    });
+                }
+                _ => {
+                    // Horizontal (Ltr/Rtl): top-to-bottom, left-to-right
+                    sorted_chars.sort_by(|a, b| {
+                        a.bbox
+                            .top
+                            .partial_cmp(&b.bbox.top)
+                            .unwrap()
+                            .then(a.bbox.x0.partial_cmp(&b.bbox.x0).unwrap())
+                    });
+                }
+            }
         }
+
+        let is_vertical = matches!(
+            options.text_direction,
+            TextDirection::Ttb | TextDirection::Btt
+        );
 
         let mut words = Vec::new();
         let mut current_chars: Vec<Char> = Vec::new();
@@ -86,11 +122,14 @@ impl WordExtractor {
             }
 
             let last = current_chars.last().unwrap();
-            let x_gap = ch.bbox.x0 - last.bbox.x1;
-            let y_diff = (ch.bbox.top - last.bbox.top).abs();
 
-            if x_gap > options.x_tolerance || y_diff > options.y_tolerance {
-                // Gap too large — start a new word
+            let should_split = if is_vertical {
+                Self::should_split_vertical(last, ch, options)
+            } else {
+                Self::should_split_horizontal(last, ch, options)
+            };
+
+            if should_split {
                 words.push(Self::make_word(&current_chars));
                 current_chars.clear();
             }
@@ -103,6 +142,43 @@ impl WordExtractor {
         }
 
         words
+    }
+
+    /// Determine the effective x-tolerance between two characters.
+    ///
+    /// For CJK characters, uses the previous character's width as tolerance,
+    /// which accounts for the wider spacing of full-width characters.
+    fn effective_x_tolerance(last: &Char, current: &Char, base: f64) -> f64 {
+        if is_cjk_text(&last.text) || is_cjk_text(&current.text) {
+            last.bbox.width().max(base)
+        } else {
+            base
+        }
+    }
+
+    /// Determine the effective y-tolerance between two characters (for vertical text).
+    fn effective_y_tolerance(last: &Char, current: &Char, base: f64) -> f64 {
+        if is_cjk_text(&last.text) || is_cjk_text(&current.text) {
+            last.bbox.height().max(base)
+        } else {
+            base
+        }
+    }
+
+    /// Check if two horizontally-adjacent chars should be split into separate words.
+    fn should_split_horizontal(last: &Char, current: &Char, options: &WordOptions) -> bool {
+        let x_gap = current.bbox.x0 - last.bbox.x1;
+        let y_diff = (current.bbox.top - last.bbox.top).abs();
+        let x_tol = Self::effective_x_tolerance(last, current, options.x_tolerance);
+        x_gap > x_tol || y_diff > options.y_tolerance
+    }
+
+    /// Check if two vertically-adjacent chars should be split into separate words.
+    fn should_split_vertical(last: &Char, current: &Char, options: &WordOptions) -> bool {
+        let y_gap = current.bbox.top - last.bbox.bottom;
+        let x_diff = (current.bbox.x0 - last.bbox.x0).abs();
+        let y_tol = Self::effective_y_tolerance(last, current, options.y_tolerance);
+        y_gap > y_tol || x_diff > options.x_tolerance
     }
 
     fn make_word(chars: &[Char]) -> Word {
@@ -421,5 +497,209 @@ mod tests {
         assert_eq!(words.len(), 2);
         assert_eq!(words[0].text, "AB");
         assert_eq!(words[1].text, "CD");
+    }
+
+    // --- CJK word grouping tests (US-020) ---
+
+    /// Helper to create a CJK character (full-width, typically 12pt wide).
+    fn make_cjk_char(text: &str, x0: f64, top: f64, width: f64, height: f64) -> Char {
+        Char {
+            text: text.to_string(),
+            bbox: BBox::new(x0, top, x0 + width, top + height),
+            fontname: "SimSun".to_string(),
+            size: 12.0,
+        }
+    }
+
+    #[test]
+    fn test_chinese_text_grouping() {
+        // "中国人" — 3 consecutive CJK characters, each 12pt wide with small gaps
+        // With default x_tolerance=3, a gap of 1 between 12pt-wide chars should group
+        let chars = vec![
+            make_cjk_char("中", 10.0, 100.0, 12.0, 12.0),
+            make_cjk_char("国", 23.0, 100.0, 12.0, 12.0), // gap = 23-22 = 1
+            make_cjk_char("人", 36.0, 100.0, 12.0, 12.0), // gap = 36-35 = 1
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].text, "中国人");
+    }
+
+    #[test]
+    fn test_chinese_text_with_larger_gap_uses_char_width_tolerance() {
+        // CJK chars with gap=8, which exceeds default x_tolerance=3
+        // but CJK-aware logic should use char width (12) as tolerance
+        let chars = vec![
+            make_cjk_char("中", 10.0, 100.0, 12.0, 12.0),
+            make_cjk_char("国", 30.0, 100.0, 12.0, 12.0), // gap = 30-22 = 8 > 3 but < 12
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(
+            words.len(),
+            1,
+            "CJK chars within char-width tolerance should group"
+        );
+        assert_eq!(words[0].text, "中国");
+    }
+
+    #[test]
+    fn test_chinese_text_large_gap_splits() {
+        // CJK chars with gap=15, exceeding char width (12)
+        let chars = vec![
+            make_cjk_char("中", 10.0, 100.0, 12.0, 12.0),
+            make_cjk_char("国", 37.0, 100.0, 12.0, 12.0), // gap = 37-22 = 15 > 12
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(
+            words.len(),
+            2,
+            "CJK chars beyond char-width tolerance should split"
+        );
+        assert_eq!(words[0].text, "中");
+        assert_eq!(words[1].text, "国");
+    }
+
+    #[test]
+    fn test_japanese_mixed_text() {
+        // "日本語abc" — CJK followed by Latin
+        let chars = vec![
+            make_cjk_char("日", 10.0, 100.0, 12.0, 12.0),
+            make_cjk_char("本", 23.0, 100.0, 12.0, 12.0), // gap=1
+            make_cjk_char("語", 36.0, 100.0, 12.0, 12.0), // gap=1
+            make_char("a", 49.0, 100.0, 55.0, 112.0),     // gap=1
+            make_char("b", 55.0, 100.0, 61.0, 112.0),     // gap=0
+            make_char("c", 61.0, 100.0, 67.0, 112.0),     // gap=0
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].text, "日本語abc");
+    }
+
+    #[test]
+    fn test_korean_text_grouping() {
+        // "한글" — 2 Korean characters
+        let chars = vec![
+            make_cjk_char("한", 10.0, 100.0, 12.0, 12.0),
+            make_cjk_char("글", 23.0, 100.0, 12.0, 12.0), // gap=1
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].text, "한글");
+    }
+
+    #[test]
+    fn test_mixed_cjk_latin_with_gap() {
+        // "Hello" then gap then "中国" — should be two words
+        let chars = vec![
+            make_char("H", 10.0, 100.0, 18.0, 112.0),
+            make_char("e", 18.0, 100.0, 24.0, 112.0),
+            make_char("l", 24.0, 100.0, 28.0, 112.0),
+            make_char("l", 28.0, 100.0, 32.0, 112.0),
+            make_char("o", 32.0, 100.0, 38.0, 112.0),
+            // gap of 20 (well beyond any tolerance)
+            make_cjk_char("中", 58.0, 100.0, 12.0, 12.0),
+            make_cjk_char("国", 71.0, 100.0, 12.0, 12.0), // gap=1
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0].text, "Hello");
+        assert_eq!(words[1].text, "中国");
+    }
+
+    #[test]
+    fn test_cjk_transition_to_latin_uses_cjk_tolerance() {
+        // CJK char followed by Latin char with gap=5 (> default 3, but < CJK width 12)
+        let chars = vec![
+            make_cjk_char("中", 10.0, 100.0, 12.0, 12.0),
+            make_char("A", 27.0, 100.0, 33.0, 112.0), // gap = 27-22 = 5
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(
+            words.len(),
+            1,
+            "CJK-to-Latin transition should use CJK tolerance"
+        );
+        assert_eq!(words[0].text, "中A");
+    }
+
+    #[test]
+    fn test_vertical_text_chinese() {
+        // Vertical text: chars stacked top-to-bottom in a column
+        // "中国人" flowing vertically at x=100
+        let chars = vec![
+            make_cjk_char("中", 100.0, 10.0, 12.0, 12.0),
+            make_cjk_char("国", 100.0, 23.0, 12.0, 12.0), // y_gap = 23-22 = 1
+            make_cjk_char("人", 100.0, 36.0, 12.0, 12.0), // y_gap = 36-35 = 1
+        ];
+        let opts = WordOptions {
+            text_direction: TextDirection::Ttb,
+            ..WordOptions::default()
+        };
+        let words = WordExtractor::extract(&chars, &opts);
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].text, "中国人");
+    }
+
+    #[test]
+    fn test_vertical_text_two_columns() {
+        // Two vertical columns: column 1 at x=100, column 2 at x=70
+        // Vertical text reads right-to-left (column1 first, column2 second)
+        let chars = vec![
+            // Column 1 (right side, x=100)
+            make_cjk_char("一", 100.0, 10.0, 12.0, 12.0),
+            make_cjk_char("二", 100.0, 23.0, 12.0, 12.0),
+            // Column 2 (left side, x=70)
+            make_cjk_char("三", 70.0, 10.0, 12.0, 12.0),
+            make_cjk_char("四", 70.0, 23.0, 12.0, 12.0),
+        ];
+        let opts = WordOptions {
+            text_direction: TextDirection::Ttb,
+            ..WordOptions::default()
+        };
+        let words = WordExtractor::extract(&chars, &opts);
+        assert_eq!(words.len(), 2);
+        // Right column first in reading order (right-to-left)
+        assert_eq!(words[0].text, "一二");
+        assert_eq!(words[1].text, "三四");
+    }
+
+    #[test]
+    fn test_vertical_text_with_gap() {
+        // Vertical CJK chars with large vertical gap
+        let chars = vec![
+            make_cjk_char("上", 100.0, 10.0, 12.0, 12.0),
+            make_cjk_char("下", 100.0, 40.0, 12.0, 12.0), // y_gap = 40-22 = 18 > 12
+        ];
+        let opts = WordOptions {
+            text_direction: TextDirection::Ttb,
+            ..WordOptions::default()
+        };
+        let words = WordExtractor::extract(&chars, &opts);
+        assert_eq!(
+            words.len(),
+            2,
+            "Vertical CJK chars with large gap should split"
+        );
+        assert_eq!(words[0].text, "上");
+        assert_eq!(words[1].text, "下");
+    }
+
+    #[test]
+    fn test_cjk_with_space_splits() {
+        // CJK chars separated by a space character should still split on the space
+        let chars = vec![
+            make_cjk_char("中", 10.0, 100.0, 12.0, 12.0),
+            Char {
+                text: " ".to_string(),
+                bbox: BBox::new(22.0, 100.0, 25.0, 112.0),
+                fontname: "SimSun".to_string(),
+                size: 12.0,
+            },
+            make_cjk_char("国", 25.0, 100.0, 12.0, 12.0),
+        ];
+        let words = WordExtractor::extract(&chars, &WordOptions::default());
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0].text, "中");
+        assert_eq!(words[1].text, "国");
     }
 }

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -12,7 +12,9 @@
 mod page;
 
 pub use page::Page;
-pub use pdfplumber_core::{BBox, Char, Word, WordExtractor, WordOptions};
+pub use pdfplumber_core::{
+    BBox, Char, TextDirection, Word, WordExtractor, WordOptions, is_cjk, is_cjk_text,
+};
 pub use pdfplumber_parse;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Added `TextDirection` enum (Ltr, Rtl, Ttb, Btt) for vertical/horizontal text support
- Added `is_cjk()` / `is_cjk_text()` functions detecting CJK characters across 11 Unicode blocks (CJK Unified Ideographs, Hiragana, Katakana, Hangul, Bopomofo, etc.)
- Enhanced `WordExtractor` with CJK-aware tolerance: uses character width (not fixed `x_tolerance`) when grouping CJK chars
- Added vertical text support (Ttb/Btt): sorts columns right-to-left, uses char height as tolerance, checks y-gap for word breaks
- Added `text_direction` field to `WordOptions` (default: Ltr, backward compatible)

## Test plan
- [x] Chinese text grouping (3 chars, small gap)
- [x] CJK char-width-based tolerance (gap=8 groups, gap=15 splits)
- [x] Japanese mixed text (CJK + Latin in same word)
- [x] Korean text grouping
- [x] Mixed CJK/Latin with large gap splits
- [x] CJK-to-Latin transition uses CJK tolerance
- [x] Vertical text (Ttb): single column
- [x] Vertical text: two columns (right-to-left reading order)
- [x] Vertical text: large gap splits
- [x] CJK with space char splits
- [x] All 53 existing tests still pass
- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test`, `cargo check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)