### PR TITLE
feat: US-021 - Graphics path operators - m, l, c, v, y, h, re

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -5,9 +5,11 @@
 //! It has no external dependencies — all functionality is pure Rust.
 
 pub mod geometry;
+pub mod path;
 pub mod text;
 pub mod words;
 
-pub use geometry::BBox;
+pub use geometry::{BBox, Ctm, Point};
+pub use path::{Path, PathBuilder, PathSegment};
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber-core/src/path.rs
+++ b/crates/pdfplumber-core/src/path.rs
@@ -1,0 +1,562 @@
+use crate::geometry::{Ctm, Point};
+
+/// A segment of a PDF path.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PathSegment {
+    /// Move to a new point (starts a new subpath).
+    MoveTo(Point),
+    /// Straight line from current point to target.
+    LineTo(Point),
+    /// Cubic Bezier curve with two control points and an endpoint.
+    CurveTo { cp1: Point, cp2: Point, end: Point },
+    /// Close the current subpath (line back to the subpath start).
+    ClosePath,
+}
+
+/// A complete path consisting of segments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Path {
+    pub segments: Vec<PathSegment>,
+}
+
+/// Builder for constructing paths from PDF path operators.
+///
+/// Coordinates are transformed through the CTM before storage.
+#[derive(Debug, Clone)]
+pub struct PathBuilder {
+    segments: Vec<PathSegment>,
+    current_point: Option<Point>,
+    subpath_start: Option<Point>,
+    ctm: Ctm,
+}
+
+impl PathBuilder {
+    /// Create a new PathBuilder with the given CTM.
+    pub fn new(ctm: Ctm) -> Self {
+        Self {
+            segments: Vec::new(),
+            current_point: None,
+            subpath_start: None,
+            ctm,
+        }
+    }
+
+    /// Update the CTM.
+    pub fn set_ctm(&mut self, ctm: Ctm) {
+        self.ctm = ctm;
+    }
+
+    /// Get the current CTM.
+    pub fn ctm(&self) -> &Ctm {
+        &self.ctm
+    }
+
+    /// `m` operator: move to a new point, starting a new subpath.
+    pub fn move_to(&mut self, x: f64, y: f64) {
+        let p = self.ctm.transform_point(Point::new(x, y));
+        self.segments.push(PathSegment::MoveTo(p));
+        self.current_point = Some(p);
+        self.subpath_start = Some(p);
+    }
+
+    /// `l` operator: straight line from current point to `(x, y)`.
+    pub fn line_to(&mut self, x: f64, y: f64) {
+        let p = self.ctm.transform_point(Point::new(x, y));
+        self.segments.push(PathSegment::LineTo(p));
+        self.current_point = Some(p);
+    }
+
+    /// `c` operator: cubic Bezier curve with three coordinate pairs.
+    pub fn curve_to(&mut self, x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) {
+        let cp1 = self.ctm.transform_point(Point::new(x1, y1));
+        let cp2 = self.ctm.transform_point(Point::new(x2, y2));
+        let end = self.ctm.transform_point(Point::new(x3, y3));
+        self.segments.push(PathSegment::CurveTo { cp1, cp2, end });
+        self.current_point = Some(end);
+    }
+
+    /// `v` operator: cubic Bezier where first control point equals current point.
+    pub fn curve_to_v(&mut self, x2: f64, y2: f64, x3: f64, y3: f64) {
+        let Some(cp1) = self.current_point else {
+            return;
+        };
+        let cp2 = self.ctm.transform_point(Point::new(x2, y2));
+        let end = self.ctm.transform_point(Point::new(x3, y3));
+        self.segments.push(PathSegment::CurveTo { cp1, cp2, end });
+        self.current_point = Some(end);
+    }
+
+    /// `y` operator: cubic Bezier where last control point equals endpoint.
+    pub fn curve_to_y(&mut self, x1: f64, y1: f64, x3: f64, y3: f64) {
+        let cp1 = self.ctm.transform_point(Point::new(x1, y1));
+        let end = self.ctm.transform_point(Point::new(x3, y3));
+        self.segments
+            .push(PathSegment::CurveTo { cp1, cp2: end, end });
+        self.current_point = Some(end);
+    }
+
+    /// `h` operator: close the current subpath.
+    pub fn close_path(&mut self) {
+        self.segments.push(PathSegment::ClosePath);
+        if let Some(start) = self.subpath_start {
+            self.current_point = Some(start);
+        }
+    }
+
+    /// `re` operator: append a rectangle as moveto + 3 lineto + closepath.
+    pub fn rectangle(&mut self, x: f64, y: f64, width: f64, height: f64) {
+        self.move_to(x, y);
+        self.line_to(x + width, y);
+        self.line_to(x + width, y + height);
+        self.line_to(x, y + height);
+        self.close_path();
+    }
+
+    /// Get the current point (already CTM-transformed).
+    pub fn current_point(&self) -> Option<Point> {
+        self.current_point
+    }
+
+    /// Consume the builder and return the constructed path.
+    pub fn build(self) -> Path {
+        Path {
+            segments: self.segments,
+        }
+    }
+
+    /// Check if the builder has no segments.
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_point_approx(p: Point, x: f64, y: f64) {
+        assert!((p.x - x).abs() < 1e-10, "x: expected {x}, got {}", p.x);
+        assert!((p.y - y).abs() < 1e-10, "y: expected {y}, got {}", p.y);
+    }
+
+    // --- PathBuilder: empty state ---
+
+    #[test]
+    fn test_new_builder_is_empty() {
+        let builder = PathBuilder::new(Ctm::identity());
+        assert!(builder.is_empty());
+        assert!(builder.current_point().is_none());
+    }
+
+    // --- m (moveto) ---
+
+    #[test]
+    fn test_move_to() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(10.0, 20.0);
+
+        assert!(!builder.is_empty());
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 10.0, 20.0);
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 1);
+        assert_eq!(
+            path.segments[0],
+            PathSegment::MoveTo(Point::new(10.0, 20.0))
+        );
+    }
+
+    #[test]
+    fn test_move_to_updates_subpath_start() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(10.0, 20.0);
+        builder.line_to(30.0, 40.0);
+        builder.close_path();
+
+        // After close, current point should return to subpath start (10, 20)
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 10.0, 20.0);
+    }
+
+    // --- l (lineto) ---
+
+    #[test]
+    fn test_line_to() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(0.0, 0.0);
+        builder.line_to(100.0, 50.0);
+
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 100.0, 50.0);
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 2);
+        assert_eq!(
+            path.segments[1],
+            PathSegment::LineTo(Point::new(100.0, 50.0))
+        );
+    }
+
+    // --- c (curveto) ---
+
+    #[test]
+    fn test_curve_to() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(0.0, 0.0);
+        builder.curve_to(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);
+
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 50.0, 60.0);
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 2);
+        assert_eq!(
+            path.segments[1],
+            PathSegment::CurveTo {
+                cp1: Point::new(10.0, 20.0),
+                cp2: Point::new(30.0, 40.0),
+                end: Point::new(50.0, 60.0),
+            }
+        );
+    }
+
+    // --- v (curveto variant: first CP = current point) ---
+
+    #[test]
+    fn test_curve_to_v() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(5.0, 10.0);
+        builder.curve_to_v(30.0, 40.0, 50.0, 60.0);
+
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 50.0, 60.0);
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 2);
+        assert_eq!(
+            path.segments[1],
+            PathSegment::CurveTo {
+                cp1: Point::new(5.0, 10.0), // first CP = current point at time of call
+                cp2: Point::new(30.0, 40.0),
+                end: Point::new(50.0, 60.0),
+            }
+        );
+    }
+
+    #[test]
+    fn test_curve_to_v_without_current_point_is_noop() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.curve_to_v(30.0, 40.0, 50.0, 60.0);
+
+        assert!(builder.is_empty());
+        assert!(builder.current_point().is_none());
+    }
+
+    // --- y (curveto variant: last CP = endpoint) ---
+
+    #[test]
+    fn test_curve_to_y() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(0.0, 0.0);
+        builder.curve_to_y(10.0, 20.0, 50.0, 60.0);
+
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 50.0, 60.0);
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 2);
+        assert_eq!(
+            path.segments[1],
+            PathSegment::CurveTo {
+                cp1: Point::new(10.0, 20.0),
+                cp2: Point::new(50.0, 60.0), // last CP = endpoint
+                end: Point::new(50.0, 60.0),
+            }
+        );
+    }
+
+    // --- h (closepath) ---
+
+    #[test]
+    fn test_close_path() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(10.0, 20.0);
+        builder.line_to(30.0, 40.0);
+        builder.line_to(50.0, 20.0);
+        builder.close_path();
+
+        // Current point returns to subpath start
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 10.0, 20.0);
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 4);
+        assert_eq!(path.segments[3], PathSegment::ClosePath);
+    }
+
+    // --- re (rectangle) ---
+
+    #[test]
+    fn test_rectangle() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.rectangle(10.0, 20.0, 100.0, 50.0);
+
+        let path = builder.build();
+        // re produces: moveto + 3 lineto + closepath = 5 segments
+        assert_eq!(path.segments.len(), 5);
+        assert_eq!(
+            path.segments[0],
+            PathSegment::MoveTo(Point::new(10.0, 20.0))
+        );
+        assert_eq!(
+            path.segments[1],
+            PathSegment::LineTo(Point::new(110.0, 20.0))
+        );
+        assert_eq!(
+            path.segments[2],
+            PathSegment::LineTo(Point::new(110.0, 70.0))
+        );
+        assert_eq!(
+            path.segments[3],
+            PathSegment::LineTo(Point::new(10.0, 70.0))
+        );
+        assert_eq!(path.segments[4], PathSegment::ClosePath);
+    }
+
+    #[test]
+    fn test_rectangle_current_point_at_start() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.rectangle(10.0, 20.0, 100.0, 50.0);
+
+        // After re + close, current point is the rectangle origin
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 10.0, 20.0);
+    }
+
+    // --- Combined path construction ---
+
+    #[test]
+    fn test_combined_path_triangle() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(0.0, 0.0);
+        builder.line_to(100.0, 0.0);
+        builder.line_to(50.0, 80.0);
+        builder.close_path();
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 4);
+        assert_eq!(path.segments[0], PathSegment::MoveTo(Point::new(0.0, 0.0)));
+        assert_eq!(
+            path.segments[1],
+            PathSegment::LineTo(Point::new(100.0, 0.0))
+        );
+        assert_eq!(
+            path.segments[2],
+            PathSegment::LineTo(Point::new(50.0, 80.0))
+        );
+        assert_eq!(path.segments[3], PathSegment::ClosePath);
+    }
+
+    #[test]
+    fn test_combined_path_with_curves() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(0.0, 0.0);
+        builder.line_to(50.0, 0.0);
+        builder.curve_to(60.0, 0.0, 70.0, 10.0, 70.0, 20.0);
+        builder.line_to(70.0, 50.0);
+        builder.close_path();
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 5);
+    }
+
+    #[test]
+    fn test_multiple_subpaths() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        // First subpath: a line
+        builder.move_to(0.0, 0.0);
+        builder.line_to(100.0, 0.0);
+        // Second subpath: another line
+        builder.move_to(0.0, 50.0);
+        builder.line_to(100.0, 50.0);
+
+        let path = builder.build();
+        assert_eq!(path.segments.len(), 4);
+
+        // After second moveto, close should go back to second subpath start
+    }
+
+    #[test]
+    fn test_multiple_subpaths_close_returns_to_latest_start() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(0.0, 0.0);
+        builder.line_to(100.0, 100.0);
+        builder.move_to(200.0, 200.0);
+        builder.line_to(300.0, 300.0);
+        builder.close_path();
+
+        // Close returns to the most recent moveto (200, 200)
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 200.0, 200.0);
+    }
+
+    // --- CTM-transformed paths ---
+
+    #[test]
+    fn test_ctm_translation_moveto() {
+        // CTM translates by (100, 200)
+        let ctm = Ctm::new(1.0, 0.0, 0.0, 1.0, 100.0, 200.0);
+        let mut builder = PathBuilder::new(ctm);
+        builder.move_to(10.0, 20.0);
+
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 110.0, 220.0);
+    }
+
+    #[test]
+    fn test_ctm_scaling_lineto() {
+        // CTM scales by 2x
+        let ctm = Ctm::new(2.0, 0.0, 0.0, 2.0, 0.0, 0.0);
+        let mut builder = PathBuilder::new(ctm);
+        builder.move_to(5.0, 10.0);
+        builder.line_to(15.0, 25.0);
+
+        let path = builder.build();
+        assert_eq!(
+            path.segments[0],
+            PathSegment::MoveTo(Point::new(10.0, 20.0))
+        );
+        assert_eq!(
+            path.segments[1],
+            PathSegment::LineTo(Point::new(30.0, 50.0))
+        );
+    }
+
+    #[test]
+    fn test_ctm_transformed_rectangle() {
+        // CTM: scale 2x + translate (10, 10)
+        let ctm = Ctm::new(2.0, 0.0, 0.0, 2.0, 10.0, 10.0);
+        let mut builder = PathBuilder::new(ctm);
+        builder.rectangle(0.0, 0.0, 50.0, 30.0);
+
+        let path = builder.build();
+        // (0,0) -> (10, 10)
+        assert_eq!(
+            path.segments[0],
+            PathSegment::MoveTo(Point::new(10.0, 10.0))
+        );
+        // (50,0) -> (110, 10)
+        assert_eq!(
+            path.segments[1],
+            PathSegment::LineTo(Point::new(110.0, 10.0))
+        );
+        // (50,30) -> (110, 70)
+        assert_eq!(
+            path.segments[2],
+            PathSegment::LineTo(Point::new(110.0, 70.0))
+        );
+        // (0,30) -> (10, 70)
+        assert_eq!(
+            path.segments[3],
+            PathSegment::LineTo(Point::new(10.0, 70.0))
+        );
+        assert_eq!(path.segments[4], PathSegment::ClosePath);
+    }
+
+    #[test]
+    fn test_ctm_transformed_curveto() {
+        // CTM scales x by 2, y by 3
+        let ctm = Ctm::new(2.0, 0.0, 0.0, 3.0, 0.0, 0.0);
+        let mut builder = PathBuilder::new(ctm);
+        builder.move_to(0.0, 0.0);
+        builder.curve_to(10.0, 10.0, 20.0, 20.0, 30.0, 30.0);
+
+        let path = builder.build();
+        assert_eq!(
+            path.segments[1],
+            PathSegment::CurveTo {
+                cp1: Point::new(20.0, 30.0),
+                cp2: Point::new(40.0, 60.0),
+                end: Point::new(60.0, 90.0),
+            }
+        );
+    }
+
+    #[test]
+    fn test_ctm_transformed_curve_to_v() {
+        // CTM translates by (100, 0)
+        let ctm = Ctm::new(1.0, 0.0, 0.0, 1.0, 100.0, 0.0);
+        let mut builder = PathBuilder::new(ctm);
+        builder.move_to(5.0, 10.0); // transformed: (105, 10)
+        builder.curve_to_v(30.0, 40.0, 50.0, 60.0);
+
+        let path = builder.build();
+        assert_eq!(
+            path.segments[1],
+            PathSegment::CurveTo {
+                cp1: Point::new(105.0, 10.0), // current point (already transformed)
+                cp2: Point::new(130.0, 40.0),
+                end: Point::new(150.0, 60.0),
+            }
+        );
+    }
+
+    #[test]
+    fn test_ctm_transformed_curve_to_y() {
+        // CTM scales by 0.5
+        let ctm = Ctm::new(0.5, 0.0, 0.0, 0.5, 0.0, 0.0);
+        let mut builder = PathBuilder::new(ctm);
+        builder.move_to(0.0, 0.0);
+        builder.curve_to_y(20.0, 40.0, 60.0, 80.0);
+
+        let path = builder.build();
+        assert_eq!(
+            path.segments[1],
+            PathSegment::CurveTo {
+                cp1: Point::new(10.0, 20.0),
+                cp2: Point::new(30.0, 40.0), // same as endpoint
+                end: Point::new(30.0, 40.0),
+            }
+        );
+    }
+
+    #[test]
+    fn test_ctm_close_path_returns_to_transformed_start() {
+        let ctm = Ctm::new(1.0, 0.0, 0.0, 1.0, 50.0, 50.0);
+        let mut builder = PathBuilder::new(ctm);
+        builder.move_to(10.0, 20.0); // transformed: (60, 70)
+        builder.line_to(100.0, 100.0);
+        builder.close_path();
+
+        let cp = builder.current_point().unwrap();
+        assert_point_approx(cp, 60.0, 70.0);
+    }
+
+    #[test]
+    fn test_set_ctm() {
+        let mut builder = PathBuilder::new(Ctm::identity());
+        builder.move_to(10.0, 20.0); // no transform
+
+        // Change CTM to translate by (100, 100)
+        builder.set_ctm(Ctm::new(1.0, 0.0, 0.0, 1.0, 100.0, 100.0));
+        builder.line_to(10.0, 20.0); // now transformed: (110, 120)
+
+        let path = builder.build();
+        assert_eq!(
+            path.segments[0],
+            PathSegment::MoveTo(Point::new(10.0, 20.0))
+        );
+        assert_eq!(
+            path.segments[1],
+            PathSegment::LineTo(Point::new(110.0, 120.0))
+        );
+    }
+
+    #[test]
+    fn test_ctm_accessor() {
+        let ctm = Ctm::new(2.0, 0.0, 0.0, 3.0, 10.0, 20.0);
+        let builder = PathBuilder::new(ctm);
+        assert_eq!(*builder.ctm(), ctm);
+    }
+}

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -13,7 +13,8 @@ mod page;
 
 pub use page::Page;
 pub use pdfplumber_core::{
-    BBox, Char, TextDirection, Word, WordExtractor, WordOptions, is_cjk, is_cjk_text,
+    BBox, Char, Ctm, Path, PathBuilder, PathSegment, Point, TextDirection, Word, WordExtractor,
+    WordOptions, is_cjk, is_cjk_text,
 };
 pub use pdfplumber_parse;
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -74,7 +74,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -7,6 +7,11 @@
 - CJK detection: `is_cjk(char)` / `is_cjk_text(&str)` in `text.rs` — covers 11 Unicode blocks
 - TextDirection enum (Ltr/Rtl/Ttb/Btt) in `text.rs` — controls sorting and gap logic in WordExtractor
 - CJK tolerance pattern: use `last_char.bbox.width().max(base_tolerance)` for horizontal, `.height()` for vertical
+- Geometric primitives: `Point(x, y)` and `Ctm(a, b, c, d, e, f)` in `geometry.rs`
+- CTM transform: `(x', y') = (a*x + c*y + e, b*x + d*y + f)` — row-vector convention
+- PathBuilder stores CTM-transformed coordinates; current_point is always in device space
+- `v` operator uses already-transformed current_point as cp1 (no double transform)
+- `re` operator delegates to move_to/line_to/close_path for consistent CTM handling
 ---
 
 # Ralph Progress Log - Phase 2: Words & Geometry - Word Grouping, Path Extraction, Reading Order
@@ -70,4 +75,29 @@ Started: 2026년  2월 27일 금요일 23시 36분 31초 KST
   - Vertical text sorting: (x0 descending, top ascending) — right-to-left columns, top-to-bottom within column
   - Vertical gap check: `y_gap = current.top - last.bottom` and `x_diff` for column detection
   - `is_some_and()` is cleaner than `map_or(false, ...)` for Option predicate checks
+---
+
+## 2026-02-28 - US-021: Graphics path operators - m, l, c, v, y, h, re
+- **What was implemented:**
+  - `Point` struct in `crates/pdfplumber-core/src/geometry.rs` — simple 2D point (x, y)
+  - `Ctm` struct in `geometry.rs` — Current Transformation Matrix with identity, new, transform_point, concat methods
+  - `PathSegment` enum in `crates/pdfplumber-core/src/path.rs` — MoveTo, LineTo, CurveTo, ClosePath
+  - `Path` struct — collection of path segments
+  - `PathBuilder` struct — builds paths from PDF operators with CTM transformation
+  - All 7 PDF path operators: m (move_to), l (line_to), c (curve_to), v (curve_to_v), y (curve_to_y), h (close_path), re (rectangle)
+  - All coordinates transformed through CTM before storage
+  - 24 path tests + 10 geometry tests (Point/Ctm) = 34 new tests (total: 87 in workspace)
+- **Files changed:**
+  - `crates/pdfplumber-core/src/geometry.rs` — added Point, Ctm types + 10 tests
+  - `crates/pdfplumber-core/src/path.rs` (new) — PathSegment, Path, PathBuilder + 24 tests
+  - `crates/pdfplumber-core/src/lib.rs` — added path module, re-exports for Point, Ctm, Path, PathBuilder, PathSegment
+  - `crates/pdfplumber/src/lib.rs` — re-export new types from facade
+- **Dependencies added:** None (still pure Rust, zero dependencies)
+- **Learnings for future iterations:**
+  - PathBuilder stores device-space (CTM-transformed) coordinates — current_point is always post-transform
+  - `v` operator: cp1 = current_point (already transformed), cp2/end need CTM transform
+  - `y` operator: cp2 = end point (both need CTM transform)
+  - `re` operator delegates to move_to/line_to/close_path for consistent CTM handling
+  - CTM concat: `a.concat(&b)` = `a × b` — used for cm operator in content stream
+  - `subpath_start` tracks the most recent MoveTo for close_path to return to
 ---


### PR DESCRIPTION
## Summary
- Implemented `Point` and `Ctm` (Current Transformation Matrix) types in `geometry.rs`
- Created `PathBuilder` with all 7 PDF path construction operators: `m` (moveto), `l` (lineto), `c` (curveto), `v`/`y` (curveto variants), `h` (closepath), `re` (rectangle)
- All coordinates are transformed through CTM before storage
- 34 new unit tests (10 for geometry, 24 for path) — total 87 tests in workspace

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — all 87 tests pass
- [x] `cargo check --workspace` passes
- [x] Each operator tested individually (m, l, c, v, y, h, re)
- [x] Combined path construction tests (triangle, curves, multiple subpaths)
- [x] CTM-transformed paths tested (identity, translation, scaling, combined)
- [x] Edge cases: `v` without current point is no-op, closepath returns to subpath start

🤖 Generated with [Claude Code](https://claude.com/claude-code)