### PR TITLE
feat: US-024 - Curve extraction + Edge derivation

### DIFF
--- a/crates/pdfplumber-core/src/edges.rs
+++ b/crates/pdfplumber-core/src/edges.rs
@@ -1,0 +1,437 @@
+//! Edge derivation from geometric primitives.
+//!
+//! Edges are line segments derived from Lines, Rects, and Curves for
+//! use in table detection algorithms.
+
+use crate::shapes::{Curve, Line, LineOrientation, Rect};
+
+/// Source of an edge, tracking which geometric primitive it came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeSource {
+    /// Derived directly from a Line object.
+    Line,
+    /// Top edge of a Rect.
+    RectTop,
+    /// Bottom edge of a Rect.
+    RectBottom,
+    /// Left edge of a Rect.
+    RectLeft,
+    /// Right edge of a Rect.
+    RectRight,
+    /// Approximated from a Curve (chord from start to end).
+    Curve,
+}
+
+/// A line segment edge for table detection.
+///
+/// Edges are derived from Lines, Rects, and Curves and are used
+/// by the table detection algorithm to find cell boundaries.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Edge {
+    /// Left x coordinate.
+    pub x0: f64,
+    /// Top y coordinate (distance from top of page).
+    pub top: f64,
+    /// Right x coordinate.
+    pub x1: f64,
+    /// Bottom y coordinate (distance from top of page).
+    pub bottom: f64,
+    /// Edge orientation.
+    pub orientation: LineOrientation,
+    /// Where this edge was derived from.
+    pub source: EdgeSource,
+}
+
+/// Derive an Edge from a Line (direct conversion).
+pub fn edge_from_line(line: &Line) -> Edge {
+    Edge {
+        x0: line.x0,
+        top: line.top,
+        x1: line.x1,
+        bottom: line.bottom,
+        orientation: line.orientation,
+        source: EdgeSource::Line,
+    }
+}
+
+/// Derive 4 Edges from a Rect (top, bottom, left, right).
+pub fn edges_from_rect(rect: &Rect) -> Vec<Edge> {
+    vec![
+        Edge {
+            x0: rect.x0,
+            top: rect.top,
+            x1: rect.x1,
+            bottom: rect.top,
+            orientation: LineOrientation::Horizontal,
+            source: EdgeSource::RectTop,
+        },
+        Edge {
+            x0: rect.x0,
+            top: rect.bottom,
+            x1: rect.x1,
+            bottom: rect.bottom,
+            orientation: LineOrientation::Horizontal,
+            source: EdgeSource::RectBottom,
+        },
+        Edge {
+            x0: rect.x0,
+            top: rect.top,
+            x1: rect.x0,
+            bottom: rect.bottom,
+            orientation: LineOrientation::Vertical,
+            source: EdgeSource::RectLeft,
+        },
+        Edge {
+            x0: rect.x1,
+            top: rect.top,
+            x1: rect.x1,
+            bottom: rect.bottom,
+            orientation: LineOrientation::Vertical,
+            source: EdgeSource::RectRight,
+        },
+    ]
+}
+
+/// Tolerance for floating-point comparison when classifying edge orientation.
+const EDGE_AXIS_TOLERANCE: f64 = 1e-6;
+
+/// Classify orientation for an edge from two points.
+fn classify_edge_orientation(x0: f64, y0: f64, x1: f64, y1: f64) -> LineOrientation {
+    let dx = (x1 - x0).abs();
+    let dy = (y1 - y0).abs();
+    if dy < EDGE_AXIS_TOLERANCE {
+        LineOrientation::Horizontal
+    } else if dx < EDGE_AXIS_TOLERANCE {
+        LineOrientation::Vertical
+    } else {
+        LineOrientation::Diagonal
+    }
+}
+
+/// Derive an Edge from a Curve using chord approximation (start to end).
+pub fn edge_from_curve(curve: &Curve) -> Edge {
+    let (start_x, start_y) = curve.pts[0];
+    let (end_x, end_y) = curve.pts[curve.pts.len() - 1];
+
+    let x0 = start_x.min(end_x);
+    let x1 = start_x.max(end_x);
+    let top = start_y.min(end_y);
+    let bottom = start_y.max(end_y);
+    let orientation = classify_edge_orientation(start_x, start_y, end_x, end_y);
+
+    Edge {
+        x0,
+        top,
+        x1,
+        bottom,
+        orientation,
+        source: EdgeSource::Curve,
+    }
+}
+
+/// Derive all edges from collections of lines, rects, and curves.
+pub fn derive_edges(lines: &[Line], rects: &[Rect], curves: &[Curve]) -> Vec<Edge> {
+    let mut edges = Vec::new();
+
+    for line in lines {
+        edges.push(edge_from_line(line));
+    }
+
+    for rect in rects {
+        edges.extend(edges_from_rect(rect));
+    }
+
+    for curve in curves {
+        edges.push(edge_from_curve(curve));
+    }
+
+    edges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::painting::Color;
+
+    fn assert_approx(a: f64, b: f64) {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "expected {b}, got {a}, diff={}",
+            (a - b).abs()
+        );
+    }
+
+    fn make_line(x0: f64, top: f64, x1: f64, bottom: f64, orient: LineOrientation) -> Line {
+        Line {
+            x0,
+            top,
+            x1,
+            bottom,
+            line_width: 1.0,
+            stroke_color: Color::black(),
+            orientation: orient,
+        }
+    }
+
+    fn make_rect(x0: f64, top: f64, x1: f64, bottom: f64) -> Rect {
+        Rect {
+            x0,
+            top,
+            x1,
+            bottom,
+            line_width: 1.0,
+            stroke: true,
+            fill: false,
+            stroke_color: Color::black(),
+            fill_color: Color::black(),
+        }
+    }
+
+    fn make_curve(pts: Vec<(f64, f64)>) -> Curve {
+        let xs: Vec<f64> = pts.iter().map(|p| p.0).collect();
+        let ys: Vec<f64> = pts.iter().map(|p| p.1).collect();
+        Curve {
+            x0: xs.iter().cloned().fold(f64::INFINITY, f64::min),
+            top: ys.iter().cloned().fold(f64::INFINITY, f64::min),
+            x1: xs.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+            bottom: ys.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+            pts,
+            line_width: 1.0,
+            stroke: true,
+            fill: false,
+            stroke_color: Color::black(),
+            fill_color: Color::black(),
+        }
+    }
+
+    // --- Edge from Line ---
+
+    #[test]
+    fn test_edge_from_horizontal_line() {
+        let line = make_line(10.0, 50.0, 100.0, 50.0, LineOrientation::Horizontal);
+        let edge = edge_from_line(&line);
+
+        assert_approx(edge.x0, 10.0);
+        assert_approx(edge.top, 50.0);
+        assert_approx(edge.x1, 100.0);
+        assert_approx(edge.bottom, 50.0);
+        assert_eq!(edge.orientation, LineOrientation::Horizontal);
+        assert_eq!(edge.source, EdgeSource::Line);
+    }
+
+    #[test]
+    fn test_edge_from_vertical_line() {
+        let line = make_line(50.0, 10.0, 50.0, 200.0, LineOrientation::Vertical);
+        let edge = edge_from_line(&line);
+
+        assert_approx(edge.x0, 50.0);
+        assert_approx(edge.top, 10.0);
+        assert_approx(edge.x1, 50.0);
+        assert_approx(edge.bottom, 200.0);
+        assert_eq!(edge.orientation, LineOrientation::Vertical);
+        assert_eq!(edge.source, EdgeSource::Line);
+    }
+
+    #[test]
+    fn test_edge_from_diagonal_line() {
+        let line = make_line(10.0, 20.0, 100.0, 200.0, LineOrientation::Diagonal);
+        let edge = edge_from_line(&line);
+
+        assert_eq!(edge.orientation, LineOrientation::Diagonal);
+        assert_eq!(edge.source, EdgeSource::Line);
+    }
+
+    // --- Edges from Rect ---
+
+    #[test]
+    fn test_edges_from_rect_count() {
+        let rect = make_rect(10.0, 20.0, 110.0, 70.0);
+        let edges = edges_from_rect(&rect);
+        assert_eq!(edges.len(), 4);
+    }
+
+    #[test]
+    fn test_edges_from_rect_top() {
+        let rect = make_rect(10.0, 20.0, 110.0, 70.0);
+        let edges = edges_from_rect(&rect);
+        let top_edge = &edges[0];
+
+        assert_approx(top_edge.x0, 10.0);
+        assert_approx(top_edge.top, 20.0);
+        assert_approx(top_edge.x1, 110.0);
+        assert_approx(top_edge.bottom, 20.0);
+        assert_eq!(top_edge.orientation, LineOrientation::Horizontal);
+        assert_eq!(top_edge.source, EdgeSource::RectTop);
+    }
+
+    #[test]
+    fn test_edges_from_rect_bottom() {
+        let rect = make_rect(10.0, 20.0, 110.0, 70.0);
+        let edges = edges_from_rect(&rect);
+        let bottom_edge = &edges[1];
+
+        assert_approx(bottom_edge.x0, 10.0);
+        assert_approx(bottom_edge.top, 70.0);
+        assert_approx(bottom_edge.x1, 110.0);
+        assert_approx(bottom_edge.bottom, 70.0);
+        assert_eq!(bottom_edge.orientation, LineOrientation::Horizontal);
+        assert_eq!(bottom_edge.source, EdgeSource::RectBottom);
+    }
+
+    #[test]
+    fn test_edges_from_rect_left() {
+        let rect = make_rect(10.0, 20.0, 110.0, 70.0);
+        let edges = edges_from_rect(&rect);
+        let left_edge = &edges[2];
+
+        assert_approx(left_edge.x0, 10.0);
+        assert_approx(left_edge.top, 20.0);
+        assert_approx(left_edge.x1, 10.0);
+        assert_approx(left_edge.bottom, 70.0);
+        assert_eq!(left_edge.orientation, LineOrientation::Vertical);
+        assert_eq!(left_edge.source, EdgeSource::RectLeft);
+    }
+
+    #[test]
+    fn test_edges_from_rect_right() {
+        let rect = make_rect(10.0, 20.0, 110.0, 70.0);
+        let edges = edges_from_rect(&rect);
+        let right_edge = &edges[3];
+
+        assert_approx(right_edge.x0, 110.0);
+        assert_approx(right_edge.top, 20.0);
+        assert_approx(right_edge.x1, 110.0);
+        assert_approx(right_edge.bottom, 70.0);
+        assert_eq!(right_edge.orientation, LineOrientation::Vertical);
+        assert_eq!(right_edge.source, EdgeSource::RectRight);
+    }
+
+    // --- Edge from Curve (chord approximation) ---
+
+    #[test]
+    fn test_edge_from_curve_horizontal_chord() {
+        // Curve from (0, 100) to (100, 100) — chord is horizontal
+        let curve = make_curve(vec![
+            (0.0, 100.0),
+            (10.0, 50.0),
+            (90.0, 50.0),
+            (100.0, 100.0),
+        ]);
+        let edge = edge_from_curve(&curve);
+
+        assert_approx(edge.x0, 0.0);
+        assert_approx(edge.x1, 100.0);
+        assert_approx(edge.top, 100.0);
+        assert_approx(edge.bottom, 100.0);
+        assert_eq!(edge.orientation, LineOrientation::Horizontal);
+        assert_eq!(edge.source, EdgeSource::Curve);
+    }
+
+    #[test]
+    fn test_edge_from_curve_vertical_chord() {
+        // Curve from (50, 0) to (50, 100) — chord is vertical
+        let curve = make_curve(vec![
+            (50.0, 0.0),
+            (100.0, 30.0),
+            (100.0, 70.0),
+            (50.0, 100.0),
+        ]);
+        let edge = edge_from_curve(&curve);
+
+        assert_approx(edge.x0, 50.0);
+        assert_approx(edge.x1, 50.0);
+        assert_approx(edge.top, 0.0);
+        assert_approx(edge.bottom, 100.0);
+        assert_eq!(edge.orientation, LineOrientation::Vertical);
+        assert_eq!(edge.source, EdgeSource::Curve);
+    }
+
+    #[test]
+    fn test_edge_from_curve_diagonal_chord() {
+        // Curve from (0, 0) to (100, 100) — chord is diagonal
+        let curve = make_curve(vec![(0.0, 0.0), (30.0, 70.0), (70.0, 30.0), (100.0, 100.0)]);
+        let edge = edge_from_curve(&curve);
+
+        assert_approx(edge.x0, 0.0);
+        assert_approx(edge.x1, 100.0);
+        assert_approx(edge.top, 0.0);
+        assert_approx(edge.bottom, 100.0);
+        assert_eq!(edge.orientation, LineOrientation::Diagonal);
+        assert_eq!(edge.source, EdgeSource::Curve);
+    }
+
+    // --- derive_edges (combined) ---
+
+    #[test]
+    fn test_derive_edges_empty_inputs() {
+        let edges = derive_edges(&[], &[], &[]);
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn test_derive_edges_lines_only() {
+        let lines = vec![
+            make_line(0.0, 50.0, 100.0, 50.0, LineOrientation::Horizontal),
+            make_line(50.0, 0.0, 50.0, 100.0, LineOrientation::Vertical),
+        ];
+        let edges = derive_edges(&lines, &[], &[]);
+        assert_eq!(edges.len(), 2);
+        assert_eq!(edges[0].source, EdgeSource::Line);
+        assert_eq!(edges[1].source, EdgeSource::Line);
+    }
+
+    #[test]
+    fn test_derive_edges_rects_only() {
+        let rects = vec![make_rect(10.0, 20.0, 110.0, 70.0)];
+        let edges = derive_edges(&[], &rects, &[]);
+        assert_eq!(edges.len(), 4); // 4 edges per rect
+    }
+
+    #[test]
+    fn test_derive_edges_curves_only() {
+        let curves = vec![make_curve(vec![
+            (0.0, 100.0),
+            (10.0, 50.0),
+            (90.0, 50.0),
+            (100.0, 100.0),
+        ])];
+        let edges = derive_edges(&[], &[], &curves);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].source, EdgeSource::Curve);
+    }
+
+    #[test]
+    fn test_derive_edges_mixed() {
+        let lines = vec![make_line(
+            0.0,
+            50.0,
+            100.0,
+            50.0,
+            LineOrientation::Horizontal,
+        )];
+        let rects = vec![make_rect(10.0, 20.0, 110.0, 70.0)];
+        let curves = vec![make_curve(vec![
+            (0.0, 100.0),
+            (10.0, 50.0),
+            (90.0, 50.0),
+            (100.0, 100.0),
+        ])];
+        let edges = derive_edges(&lines, &rects, &curves);
+        // 1 from line + 4 from rect + 1 from curve = 6
+        assert_eq!(edges.len(), 6);
+        assert_eq!(edges[0].source, EdgeSource::Line);
+        assert_eq!(edges[1].source, EdgeSource::RectTop);
+        assert_eq!(edges[4].source, EdgeSource::RectRight);
+        assert_eq!(edges[5].source, EdgeSource::Curve);
+    }
+
+    #[test]
+    fn test_derive_edges_multiple_rects() {
+        let rects = vec![
+            make_rect(10.0, 20.0, 110.0, 70.0),
+            make_rect(200.0, 300.0, 350.0, 400.0),
+        ];
+        let edges = derive_edges(&[], &rects, &[]);
+        assert_eq!(edges.len(), 8); // 4 edges per rect × 2
+    }
+}

--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! and algorithms (text grouping, table detection) used by pdfplumber-rs.
 //! It has no external dependencies — all functionality is pure Rust.
 
+pub mod edges;
 pub mod geometry;
 pub mod painting;
 pub mod path;
@@ -11,9 +12,10 @@ pub mod shapes;
 pub mod text;
 pub mod words;
 
+pub use edges::{Edge, EdgeSource, derive_edges, edge_from_curve, edge_from_line, edges_from_rect};
 pub use geometry::{BBox, Ctm, Point};
 pub use painting::{Color, FillRule, GraphicsState, PaintedPath};
 pub use path::{Path, PathBuilder, PathSegment};
-pub use shapes::{Line, LineOrientation, Rect, extract_shapes};
+pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -13,8 +13,9 @@ mod page;
 
 pub use page::Page;
 pub use pdfplumber_core::{
-    BBox, Char, Color, Ctm, FillRule, GraphicsState, Line, LineOrientation, PaintedPath, Path,
-    PathBuilder, PathSegment, Point, Rect, TextDirection, Word, WordExtractor, WordOptions,
+    BBox, Char, Color, Ctm, Curve, Edge, EdgeSource, FillRule, GraphicsState, Line,
+    LineOrientation, PaintedPath, Path, PathBuilder, PathSegment, Point, Rect, TextDirection, Word,
+    WordExtractor, WordOptions, derive_edges, edge_from_curve, edge_from_line, edges_from_rect,
     extract_shapes, is_cjk, is_cjk_text,
 };
 pub use pdfplumber_parse;

--- a/crates/pdfplumber/src/page.rs
+++ b/crates/pdfplumber/src/page.rs
@@ -1,11 +1,13 @@
 //! Page type for accessing extracted content from a PDF page.
 
-use pdfplumber_core::{Char, Word, WordExtractor, WordOptions};
+use pdfplumber_core::{
+    Char, Curve, Edge, Line, Rect, Word, WordExtractor, WordOptions, derive_edges,
+};
 
 /// A single page from a PDF document.
 ///
-/// Provides access to characters, words, and other content extracted from
-/// the page. Constructed internally by the PDF parsing pipeline.
+/// Provides access to characters, words, lines, rects, curves, and edges
+/// extracted from the page. Constructed internally by the PDF parsing pipeline.
 pub struct Page {
     /// Page index (0-based).
     page_number: usize,
@@ -15,6 +17,12 @@ pub struct Page {
     height: f64,
     /// Characters extracted from this page.
     chars: Vec<Char>,
+    /// Lines extracted from painted paths.
+    lines: Vec<Line>,
+    /// Rectangles extracted from painted paths.
+    rects: Vec<Rect>,
+    /// Curves extracted from painted paths.
+    curves: Vec<Curve>,
 }
 
 impl Page {
@@ -25,6 +33,30 @@ impl Page {
             width,
             height,
             chars,
+            lines: Vec::new(),
+            rects: Vec::new(),
+            curves: Vec::new(),
+        }
+    }
+
+    /// Create a new page with characters and geometry.
+    pub fn with_geometry(
+        page_number: usize,
+        width: f64,
+        height: f64,
+        chars: Vec<Char>,
+        lines: Vec<Line>,
+        rects: Vec<Rect>,
+        curves: Vec<Curve>,
+    ) -> Self {
+        Self {
+            page_number,
+            width,
+            height,
+            chars,
+            lines,
+            rects,
+            curves,
         }
     }
 
@@ -48,6 +80,29 @@ impl Page {
         &self.chars
     }
 
+    /// Returns the lines extracted from this page.
+    pub fn lines(&self) -> &[Line] {
+        &self.lines
+    }
+
+    /// Returns the rectangles extracted from this page.
+    pub fn rects(&self) -> &[Rect] {
+        &self.rects
+    }
+
+    /// Returns the curves extracted from this page.
+    pub fn curves(&self) -> &[Curve] {
+        &self.curves
+    }
+
+    /// Compute edges from all geometric primitives (lines, rects, curves).
+    ///
+    /// Edges are line segments derived from all geometric objects on the page,
+    /// suitable for table detection. Each edge tracks its source (Line, Rect side, Curve chord).
+    pub fn edges(&self) -> Vec<Edge> {
+        derive_edges(&self.lines, &self.rects, &self.curves)
+    }
+
     /// Extract words from this page using the specified options.
     ///
     /// Groups characters into words based on spatial proximity using
@@ -60,7 +115,7 @@ impl Page {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pdfplumber_core::BBox;
+    use pdfplumber_core::{BBox, Color, EdgeSource, LineOrientation};
 
     fn make_char(text: &str, x0: f64, top: f64, x1: f64, bottom: f64) -> Char {
         Char {
@@ -68,6 +123,49 @@ mod tests {
             bbox: BBox::new(x0, top, x1, bottom),
             fontname: "TestFont".to_string(),
             size: 12.0,
+        }
+    }
+
+    fn make_line(x0: f64, top: f64, x1: f64, bottom: f64, orient: LineOrientation) -> Line {
+        Line {
+            x0,
+            top,
+            x1,
+            bottom,
+            line_width: 1.0,
+            stroke_color: Color::black(),
+            orientation: orient,
+        }
+    }
+
+    fn make_rect(x0: f64, top: f64, x1: f64, bottom: f64) -> Rect {
+        Rect {
+            x0,
+            top,
+            x1,
+            bottom,
+            line_width: 1.0,
+            stroke: true,
+            fill: false,
+            stroke_color: Color::black(),
+            fill_color: Color::black(),
+        }
+    }
+
+    fn make_curve(pts: Vec<(f64, f64)>) -> Curve {
+        let xs: Vec<f64> = pts.iter().map(|p| p.0).collect();
+        let ys: Vec<f64> = pts.iter().map(|p| p.1).collect();
+        Curve {
+            x0: xs.iter().cloned().fold(f64::INFINITY, f64::min),
+            top: ys.iter().cloned().fold(f64::INFINITY, f64::min),
+            x1: xs.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+            bottom: ys.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+            pts,
+            line_width: 1.0,
+            stroke: true,
+            fill: false,
+            stroke_color: Color::black(),
+            fill_color: Color::black(),
         }
     }
 
@@ -214,5 +312,91 @@ mod tests {
         assert_eq!(words[0].chars[1].text, "B");
         assert_eq!(words[0].chars[0].bbox, BBox::new(10.0, 100.0, 20.0, 112.0));
         assert_eq!(words[0].chars[1].bbox, BBox::new(20.0, 100.0, 30.0, 112.0));
+    }
+
+    // --- Geometry accessors ---
+
+    #[test]
+    fn test_page_new_has_empty_geometry() {
+        let page = Page::new(0, 612.0, 792.0, vec![]);
+        assert!(page.lines().is_empty());
+        assert!(page.rects().is_empty());
+        assert!(page.curves().is_empty());
+        assert!(page.edges().is_empty());
+    }
+
+    #[test]
+    fn test_page_with_geometry() {
+        let lines = vec![make_line(
+            0.0,
+            50.0,
+            100.0,
+            50.0,
+            LineOrientation::Horizontal,
+        )];
+        let rects = vec![make_rect(10.0, 20.0, 110.0, 70.0)];
+        let curves = vec![make_curve(vec![
+            (0.0, 100.0),
+            (10.0, 50.0),
+            (90.0, 50.0),
+            (100.0, 100.0),
+        ])];
+        let page = Page::with_geometry(0, 612.0, 792.0, vec![], lines, rects, curves);
+
+        assert_eq!(page.lines().len(), 1);
+        assert_eq!(page.rects().len(), 1);
+        assert_eq!(page.curves().len(), 1);
+    }
+
+    #[test]
+    fn test_page_edges_from_lines() {
+        let lines = vec![
+            make_line(0.0, 50.0, 100.0, 50.0, LineOrientation::Horizontal),
+            make_line(50.0, 0.0, 50.0, 100.0, LineOrientation::Vertical),
+        ];
+        let page = Page::with_geometry(0, 612.0, 792.0, vec![], lines, vec![], vec![]);
+        let edges = page.edges();
+
+        assert_eq!(edges.len(), 2);
+        assert_eq!(edges[0].source, EdgeSource::Line);
+        assert_eq!(edges[1].source, EdgeSource::Line);
+    }
+
+    #[test]
+    fn test_page_edges_from_rects() {
+        let rects = vec![make_rect(10.0, 20.0, 110.0, 70.0)];
+        let page = Page::with_geometry(0, 612.0, 792.0, vec![], vec![], rects, vec![]);
+        let edges = page.edges();
+
+        assert_eq!(edges.len(), 4);
+        assert_eq!(edges[0].source, EdgeSource::RectTop);
+        assert_eq!(edges[1].source, EdgeSource::RectBottom);
+        assert_eq!(edges[2].source, EdgeSource::RectLeft);
+        assert_eq!(edges[3].source, EdgeSource::RectRight);
+    }
+
+    #[test]
+    fn test_page_edges_combined() {
+        let lines = vec![make_line(
+            0.0,
+            50.0,
+            100.0,
+            50.0,
+            LineOrientation::Horizontal,
+        )];
+        let rects = vec![make_rect(10.0, 20.0, 110.0, 70.0)];
+        let curves = vec![make_curve(vec![
+            (0.0, 100.0),
+            (10.0, 50.0),
+            (90.0, 50.0),
+            (100.0, 100.0),
+        ])];
+        let page = Page::with_geometry(0, 612.0, 792.0, vec![], lines, rects, curves);
+        let edges = page.edges();
+
+        // 1 from line + 4 from rect + 1 from curve = 6
+        assert_eq!(edges.len(), 6);
+        assert_eq!(edges[0].source, EdgeSource::Line);
+        assert_eq!(edges[5].source, EdgeSource::Curve);
     }
 }


### PR DESCRIPTION
## Summary
- Added `Curve` struct for extracting cubic Bezier path segments with control points, bbox, and fill/stroke properties
- Added `Edge` and `EdgeSource` types for table detection edge derivation from Lines, Rects, and Curves
- Extended `extract_shapes()` to return `(Vec<Line>, Vec<Rect>, Vec<Curve>)` — curves now extracted from painted paths
- Implemented edge derivation: `edge_from_line()`, `edges_from_rect()` (4 edges per rect), `edge_from_curve()` (chord approximation)
- Added `Page::edges()` method that computes combined edges from all geometric primitives
- Added `Page::with_geometry()` constructor and `lines()/rects()/curves()` accessors

## Test plan
- [x] 8 new curve extraction tests (simple, bbox, graphics state, fill-only, multiple curves, mixed line+curve, CTM)
- [x] 17 new edge derivation tests (from line, from rect sides, from curve chord, combined derive_edges)
- [x] 5 new Page tests (empty geometry, with_geometry, edges from lines/rects, combined edges)
- [x] All 164 existing tests still pass
- [x] `cargo fmt`, `cargo clippy`, `cargo test`, `cargo check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)