### PR TITLE
feat: US-006 - lopdf backend - document open, page count, page access

### DIFF
--- a/crates/pdfplumber-parse/Cargo.toml
+++ b/crates/pdfplumber-parse/Cargo.toml
@@ -8,4 +8,5 @@ description = "PDF parsing and content stream interpreter for pdfplumber-rs"
 
 [dependencies]
 pdfplumber-core = { path = "../pdfplumber-core" }
+lopdf = "0.34"
 thiserror = "2"

--- a/crates/pdfplumber-parse/src/lib.rs
+++ b/crates/pdfplumber-parse/src/lib.rs
@@ -7,8 +7,10 @@
 pub mod backend;
 pub mod error;
 pub mod handler;
+pub mod lopdf_backend;
 
 pub use backend::PdfBackend;
 pub use error::BackendError;
 pub use handler::{CharEvent, ContentHandler, ImageEvent, PaintOp, PathEvent};
+pub use lopdf_backend::{LopdfBackend, LopdfDocument, LopdfPage};
 pub use pdfplumber_core;

--- a/crates/pdfplumber-parse/src/lopdf_backend.rs
+++ b/crates/pdfplumber-parse/src/lopdf_backend.rs
@@ -1,0 +1,294 @@
+//! lopdf-based PDF parsing backend.
+//!
+//! Implements [`PdfBackend`] using the [lopdf](https://crates.io/crates/lopdf)
+//! crate for PDF document parsing. This is the default backend for pdfplumber-rs.
+
+use crate::backend::PdfBackend;
+use crate::error::BackendError;
+use crate::handler::ContentHandler;
+use pdfplumber_core::{BBox, ExtractOptions};
+
+/// A parsed PDF document backed by lopdf.
+pub struct LopdfDocument {
+    /// The underlying lopdf document.
+    inner: lopdf::Document,
+    /// Cached ordered list of page ObjectIds (indexed by 0-based page number).
+    page_ids: Vec<lopdf::ObjectId>,
+}
+
+impl LopdfDocument {
+    /// Access the underlying lopdf document.
+    pub fn inner(&self) -> &lopdf::Document {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for LopdfDocument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LopdfDocument")
+            .field("page_count", &self.page_ids.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// A reference to a single page within a [`LopdfDocument`].
+#[derive(Debug, Clone, Copy)]
+pub struct LopdfPage {
+    /// The lopdf object ID for this page.
+    pub object_id: lopdf::ObjectId,
+    /// The 0-based page index.
+    pub index: usize,
+}
+
+/// The lopdf-based PDF backend.
+///
+/// Provides PDF parsing via [`lopdf::Document`]. This is the default
+/// backend used by pdfplumber-rs.
+///
+/// # Example
+///
+/// ```ignore
+/// use pdfplumber_parse::lopdf_backend::LopdfBackend;
+/// use pdfplumber_parse::PdfBackend;
+///
+/// let doc = LopdfBackend::open(pdf_bytes)?;
+/// let count = LopdfBackend::page_count(&doc);
+/// let page = LopdfBackend::get_page(&doc, 0)?;
+/// ```
+pub struct LopdfBackend;
+
+impl PdfBackend for LopdfBackend {
+    type Document = LopdfDocument;
+    type Page = LopdfPage;
+    type Error = BackendError;
+
+    fn open(bytes: &[u8]) -> Result<Self::Document, Self::Error> {
+        let inner = lopdf::Document::load_mem(bytes)
+            .map_err(|e| BackendError::Parse(format!("failed to parse PDF: {e}")))?;
+
+        // Cache page IDs in order (get_pages returns BTreeMap<u32, ObjectId> with 1-based keys)
+        let pages_map = inner.get_pages();
+        let page_ids: Vec<lopdf::ObjectId> = pages_map.values().copied().collect();
+
+        Ok(LopdfDocument { inner, page_ids })
+    }
+
+    fn page_count(doc: &Self::Document) -> usize {
+        doc.page_ids.len()
+    }
+
+    fn get_page(doc: &Self::Document, index: usize) -> Result<Self::Page, Self::Error> {
+        if index >= doc.page_ids.len() {
+            return Err(BackendError::Parse(format!(
+                "page index {index} out of range (0..{})",
+                doc.page_ids.len()
+            )));
+        }
+        Ok(LopdfPage {
+            object_id: doc.page_ids[index],
+            index,
+        })
+    }
+
+    fn page_media_box(_doc: &Self::Document, _page: &Self::Page) -> Result<BBox, Self::Error> {
+        // Stub: will be implemented in US-007
+        todo!("page_media_box not yet implemented")
+    }
+
+    fn page_crop_box(
+        _doc: &Self::Document,
+        _page: &Self::Page,
+    ) -> Result<Option<BBox>, Self::Error> {
+        // Stub: will be implemented in US-007
+        todo!("page_crop_box not yet implemented")
+    }
+
+    fn page_rotate(_doc: &Self::Document, _page: &Self::Page) -> Result<i32, Self::Error> {
+        // Stub: will be implemented in US-007
+        todo!("page_rotate not yet implemented")
+    }
+
+    fn interpret_page(
+        _doc: &Self::Document,
+        _page: &Self::Page,
+        _handler: &mut dyn ContentHandler,
+        _options: &ExtractOptions,
+    ) -> Result<(), Self::Error> {
+        // Stub: will be implemented in later stories
+        todo!("interpret_page not yet implemented")
+    }
+}
+
+/// Create a minimal valid PDF document with the given number of pages.
+///
+/// Each page is US Letter size (612 x 792 points) with no content.
+/// Used for testing purposes.
+#[cfg(test)]
+fn create_test_pdf(page_count: usize) -> Vec<u8> {
+    use lopdf::{Document, Object, ObjectId, dictionary};
+
+    let mut doc = Document::with_version("1.5");
+    let pages_id: ObjectId = doc.new_object_id();
+
+    let mut page_ids: Vec<Object> = Vec::new();
+    for _ in 0..page_count {
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        });
+        page_ids.push(page_id.into());
+    }
+
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => page_ids,
+            "Count" => page_count as i64,
+        }),
+    );
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).expect("failed to save test PDF");
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pdfplumber_core::PdfError;
+
+    // --- open() tests ---
+
+    #[test]
+    fn open_valid_single_page_pdf() {
+        let pdf_bytes = create_test_pdf(1);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        assert_eq!(LopdfBackend::page_count(&doc), 1);
+    }
+
+    #[test]
+    fn open_valid_multi_page_pdf() {
+        let pdf_bytes = create_test_pdf(5);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        assert_eq!(LopdfBackend::page_count(&doc), 5);
+    }
+
+    #[test]
+    fn open_invalid_bytes_returns_error() {
+        let result = LopdfBackend::open(b"not a pdf");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn open_empty_bytes_returns_error() {
+        let result = LopdfBackend::open(&[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn open_error_converts_to_pdf_error() {
+        let err = LopdfBackend::open(b"garbage").unwrap_err();
+        let pdf_err: PdfError = err.into();
+        assert!(matches!(pdf_err, PdfError::ParseError(_)));
+    }
+
+    // --- page_count() tests ---
+
+    #[test]
+    fn page_count_zero_pages() {
+        let pdf_bytes = create_test_pdf(0);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        assert_eq!(LopdfBackend::page_count(&doc), 0);
+    }
+
+    #[test]
+    fn page_count_three_pages() {
+        let pdf_bytes = create_test_pdf(3);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        assert_eq!(LopdfBackend::page_count(&doc), 3);
+    }
+
+    // --- get_page() tests ---
+
+    #[test]
+    fn get_page_first_page() {
+        let pdf_bytes = create_test_pdf(3);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        assert_eq!(page.index, 0);
+    }
+
+    #[test]
+    fn get_page_last_page() {
+        let pdf_bytes = create_test_pdf(3);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 2).unwrap();
+        assert_eq!(page.index, 2);
+    }
+
+    #[test]
+    fn get_page_out_of_bounds() {
+        let pdf_bytes = create_test_pdf(2);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let result = LopdfBackend::get_page(&doc, 2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_page_out_of_bounds_error_converts_to_pdf_error() {
+        let pdf_bytes = create_test_pdf(1);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let err = LopdfBackend::get_page(&doc, 5).unwrap_err();
+        let pdf_err: PdfError = err.into();
+        assert!(matches!(pdf_err, PdfError::ParseError(_)));
+        assert!(pdf_err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn get_page_on_empty_document() {
+        let pdf_bytes = create_test_pdf(0);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let result = LopdfBackend::get_page(&doc, 0);
+        assert!(result.is_err());
+    }
+
+    // --- Page object IDs are distinct ---
+
+    #[test]
+    fn pages_have_distinct_object_ids() {
+        let pdf_bytes = create_test_pdf(3);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page0 = LopdfBackend::get_page(&doc, 0).unwrap();
+        let page1 = LopdfBackend::get_page(&doc, 1).unwrap();
+        let page2 = LopdfBackend::get_page(&doc, 2).unwrap();
+        assert_ne!(page0.object_id, page1.object_id);
+        assert_ne!(page1.object_id, page2.object_id);
+        assert_ne!(page0.object_id, page2.object_id);
+    }
+
+    // --- Integration: open + page_count + get_page round-trip ---
+
+    #[test]
+    fn round_trip_open_count_access() {
+        let pdf_bytes = create_test_pdf(4);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let count = LopdfBackend::page_count(&doc);
+        assert_eq!(count, 4);
+
+        for i in 0..count {
+            let page = LopdfBackend::get_page(&doc, i).unwrap();
+            assert_eq!(page.index, i);
+        }
+
+        // One past the end should fail
+        assert!(LopdfBackend::get_page(&doc, count).is_err());
+    }
+}

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -23,7 +23,8 @@ pub use pdfplumber_core::{
     split_lines_at_columns, words_to_text,
 };
 pub use pdfplumber_parse::{
-    self, CharEvent, ContentHandler, ImageEvent, PaintOp, PathEvent, PdfBackend,
+    self, CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, LopdfPage, PaintOp,
+    PathEvent, PdfBackend,
 };
 
 #[cfg(test)]

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -111,8 +111,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 6,
-      "passes": false,
-      "notes": "Add lopdf as dependency to pdfplumber-parse."
+      "passes": true,
+      "notes": "LopdfBackend implements PdfBackend for open/page_count/get_page. lopdf 0.34 added as dependency. LopdfDocument wraps lopdf::Document + cached page_ids. LopdfPage holds ObjectId + index. Stub methods for page_media_box/page_crop_box/page_rotate/interpret_page (US-007+). Test PDFs created programmatically with lopdf."
     },
     {
       "id": "US-007",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -13,6 +13,10 @@
 - ContentHandler has default no-op methods. Implementors override only the events they care about.
 - ContentHandler is object-safe: use `&mut dyn ContentHandler` in trait method signatures.
 - CTM stored as [f64; 6] in event types (CharEvent, PathEvent, ImageEvent) for consistency with Char.ctm.
+- LopdfBackend uses BackendError as its Error type (already converts to PdfError via From impl).
+- LopdfDocument caches page ObjectIds in a Vec for O(1) 0-based index access (lopdf's get_pages returns BTreeMap<u32, ObjectId> with 1-based keys).
+- LopdfDocument.inner() accessor provides read access to the underlying lopdf::Document.
+- Create test PDFs programmatically with lopdf: Document::with_version + add_object with dictionary! macro. Save to Vec<u8> with save_to().
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 01시 07분 18초 KST
@@ -94,4 +98,22 @@ Started: 2026년  2월 28일 토요일 01시 07분 18초 KST
   - CharEvent carries full text state context (matrix, spacing, scaling) for bbox calculation in later layers
   - PathEvent uses Vec<PathSegment> from core and includes paint_op, colors, dash_pattern, fill_rule
   - ImageEvent carries CTM for position/size determination + pixel dimensions and colorspace
+---
+
+## 2026-02-28 - US-006
+- What was implemented: LopdfBackend struct implementing PdfBackend trait for open/page_count/get_page operations using lopdf crate.
+- Files changed:
+  - crates/pdfplumber-parse/Cargo.toml (added lopdf = "0.34")
+  - crates/pdfplumber-parse/src/lopdf_backend.rs (new - LopdfBackend, LopdfDocument, LopdfPage, create_test_pdf helper, 14 tests)
+  - crates/pdfplumber-parse/src/lib.rs (added lopdf_backend module + exports)
+  - crates/pdfplumber/src/lib.rs (re-export LopdfBackend, LopdfDocument, LopdfPage)
+  - scripts/ralph/prd.json (marked US-006 passes: true)
+- Dependencies added: lopdf 0.34 (approved in PRD for default PDF parsing backend)
+- **Learnings for future iterations:**
+  - lopdf::Document doesn't implement Debug — need manual Debug impl for wrapper types
+  - lopdf's get_pages() returns BTreeMap<u32, ObjectId> with 1-based page numbers; cache as Vec for O(1) 0-based access
+  - pub(crate) fields still trigger dead_code warning if not read in lib target — use pub accessor methods instead
+  - lopdf's Document::load_mem parses PDF from &[u8]; errors are lopdf::Error which must be mapped to BackendError
+  - Test PDFs created with lopdf::Document::with_version + dictionary! macro + save_to(&mut Vec<u8>)
+  - Stub methods use todo!() for methods that will be implemented in later stories (US-007+)
 ---


### PR DESCRIPTION
## Summary
- Implement `LopdfBackend` struct implementing `PdfBackend` trait using lopdf 0.34
- `open()` parses PDF bytes via `lopdf::Document::load_mem()` with proper error mapping
- `page_count()` returns correct number of pages from cached page ID list
- `get_page()` returns page by 0-based index with bounds checking
- `LopdfDocument` wraps `lopdf::Document` with cached page ObjectIds for O(1) access
- `LopdfPage` holds the page's ObjectId and 0-based index
- Stub `todo!()` methods for `page_media_box`/`page_crop_box`/`page_rotate`/`interpret_page` (US-007+)
- All types re-exported from `pdfplumber` facade crate

## Test plan
- [x] `open_valid_single_page_pdf` - open 1-page PDF, verify page count
- [x] `open_valid_multi_page_pdf` - open 5-page PDF, verify page count
- [x] `open_invalid_bytes_returns_error` - non-PDF bytes return error
- [x] `open_empty_bytes_returns_error` - empty input returns error
- [x] `open_error_converts_to_pdf_error` - BackendError → PdfError conversion
- [x] `page_count_zero_pages` - 0-page PDF edge case
- [x] `page_count_three_pages` - correct count for multi-page PDF
- [x] `get_page_first_page` / `get_page_last_page` - valid index access
- [x] `get_page_out_of_bounds` - out-of-range index returns error
- [x] `get_page_on_empty_document` - accessing page on 0-page doc fails
- [x] `pages_have_distinct_object_ids` - each page has unique ObjectId
- [x] `round_trip_open_count_access` - full open→count→access round-trip
- [x] All 367 workspace tests pass
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)