### PR TITLE
feat: US-007 - lopdf backend - MediaBox, CropBox, Rotate extraction

### DIFF
--- a/crates/pdfplumber-parse/src/lopdf_backend.rs
+++ b/crates/pdfplumber-parse/src/lopdf_backend.rs
@@ -57,6 +57,62 @@ pub struct LopdfPage {
 /// ```
 pub struct LopdfBackend;
 
+/// Extract a [`BBox`] from a lopdf array of 4 numbers `[x0, y0, x1, y1]`.
+fn extract_bbox_from_array(array: &[lopdf::Object]) -> Result<BBox, BackendError> {
+    if array.len() != 4 {
+        return Err(BackendError::Parse(format!(
+            "expected 4-element array for box, got {}",
+            array.len()
+        )));
+    }
+    let x0 = object_to_f64(&array[0])?;
+    let y0 = object_to_f64(&array[1])?;
+    let x1 = object_to_f64(&array[2])?;
+    let y1 = object_to_f64(&array[3])?;
+    Ok(BBox::new(x0, y0, x1, y1))
+}
+
+/// Convert a lopdf numeric object (Integer or Real) to f64.
+fn object_to_f64(obj: &lopdf::Object) -> Result<f64, BackendError> {
+    match obj {
+        lopdf::Object::Integer(i) => Ok(*i as f64),
+        lopdf::Object::Real(f) => Ok(*f as f64),
+        _ => Err(BackendError::Parse(format!("expected number, got {obj:?}"))),
+    }
+}
+
+/// Look up a key in the page dictionary, walking up the page tree
+/// (via /Parent) if the key is not found on the page itself.
+///
+/// Returns `None` if the key is not found anywhere in the tree.
+fn resolve_inherited<'a>(
+    doc: &'a lopdf::Document,
+    page_id: lopdf::ObjectId,
+    key: &[u8],
+) -> Result<Option<&'a lopdf::Object>, BackendError> {
+    let mut current_id = page_id;
+    loop {
+        let dict = doc
+            .get_object(current_id)
+            .and_then(|o| o.as_dict())
+            .map_err(|e| BackendError::Parse(format!("failed to get page dictionary: {e}")))?;
+
+        if let Ok(value) = dict.get(key) {
+            return Ok(Some(value));
+        }
+
+        // Try to follow /Parent link
+        match dict.get(b"Parent") {
+            Ok(parent_obj) => {
+                current_id = parent_obj
+                    .as_reference()
+                    .map_err(|e| BackendError::Parse(format!("invalid /Parent reference: {e}")))?;
+            }
+            Err(_) => return Ok(None),
+        }
+    }
+}
+
 impl PdfBackend for LopdfBackend {
     type Document = LopdfDocument;
     type Page = LopdfPage;
@@ -90,22 +146,44 @@ impl PdfBackend for LopdfBackend {
         })
     }
 
-    fn page_media_box(_doc: &Self::Document, _page: &Self::Page) -> Result<BBox, Self::Error> {
-        // Stub: will be implemented in US-007
-        todo!("page_media_box not yet implemented")
+    fn page_media_box(doc: &Self::Document, page: &Self::Page) -> Result<BBox, Self::Error> {
+        let obj = resolve_inherited(&doc.inner, page.object_id, b"MediaBox")?
+            .ok_or_else(|| BackendError::Parse("MediaBox not found on page or ancestors".into()))?;
+        let array = obj
+            .as_array()
+            .map_err(|e| BackendError::Parse(format!("MediaBox is not an array: {e}")))?;
+        extract_bbox_from_array(array)
     }
 
-    fn page_crop_box(
-        _doc: &Self::Document,
-        _page: &Self::Page,
-    ) -> Result<Option<BBox>, Self::Error> {
-        // Stub: will be implemented in US-007
-        todo!("page_crop_box not yet implemented")
+    fn page_crop_box(doc: &Self::Document, page: &Self::Page) -> Result<Option<BBox>, Self::Error> {
+        // CropBox is optional — only look at the page itself, not inherited
+        let dict = doc
+            .inner
+            .get_object(page.object_id)
+            .and_then(|o| o.as_dict())
+            .map_err(|e| BackendError::Parse(format!("failed to get page dictionary: {e}")))?;
+
+        match dict.get(b"CropBox") {
+            Ok(obj) => {
+                let array = obj
+                    .as_array()
+                    .map_err(|e| BackendError::Parse(format!("CropBox is not an array: {e}")))?;
+                Ok(Some(extract_bbox_from_array(array)?))
+            }
+            Err(_) => Ok(None),
+        }
     }
 
-    fn page_rotate(_doc: &Self::Document, _page: &Self::Page) -> Result<i32, Self::Error> {
-        // Stub: will be implemented in US-007
-        todo!("page_rotate not yet implemented")
+    fn page_rotate(doc: &Self::Document, page: &Self::Page) -> Result<i32, Self::Error> {
+        match resolve_inherited(&doc.inner, page.object_id, b"Rotate")? {
+            Some(obj) => {
+                let rotation = obj
+                    .as_i64()
+                    .map_err(|e| BackendError::Parse(format!("Rotate is not an integer: {e}")))?;
+                Ok(rotation as i32)
+            }
+            None => Ok(0), // Default rotation is 0
+        }
     }
 
     fn interpret_page(
@@ -146,6 +224,152 @@ fn create_test_pdf(page_count: usize) -> Vec<u8> {
             "Type" => "Pages",
             "Kids" => page_ids,
             "Count" => page_count as i64,
+        }),
+    );
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).expect("failed to save test PDF");
+    buf
+}
+
+/// Create a PDF where pages inherit MediaBox from the Pages parent node.
+#[cfg(test)]
+fn create_test_pdf_inherited_media_box() -> Vec<u8> {
+    use lopdf::{Document, Object, ObjectId, dictionary};
+
+    let mut doc = Document::with_version("1.5");
+    let pages_id: ObjectId = doc.new_object_id();
+
+    // Page WITHOUT its own MediaBox — should inherit from parent
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+    });
+
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::from(page_id)],
+            "Count" => 1i64,
+            "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+        }),
+    );
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).expect("failed to save test PDF");
+    buf
+}
+
+/// Create a PDF with a page that has an explicit CropBox.
+#[cfg(test)]
+fn create_test_pdf_with_crop_box() -> Vec<u8> {
+    use lopdf::{Document, Object, ObjectId, dictionary};
+
+    let mut doc = Document::with_version("1.5");
+    let pages_id: ObjectId = doc.new_object_id();
+
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        "CropBox" => vec![
+            Object::Real(36.0),
+            Object::Real(36.0),
+            Object::Real(576.0),
+            Object::Real(756.0),
+        ],
+    });
+
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::from(page_id)],
+            "Count" => 1i64,
+        }),
+    );
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).expect("failed to save test PDF");
+    buf
+}
+
+/// Create a PDF with a page that has a /Rotate value.
+#[cfg(test)]
+fn create_test_pdf_with_rotate(rotation: i64) -> Vec<u8> {
+    use lopdf::{Document, Object, ObjectId, dictionary};
+
+    let mut doc = Document::with_version("1.5");
+    let pages_id: ObjectId = doc.new_object_id();
+
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        "Rotate" => rotation,
+    });
+
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::from(page_id)],
+            "Count" => 1i64,
+        }),
+    );
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).expect("failed to save test PDF");
+    buf
+}
+
+/// Create a PDF where Rotate is inherited from the Pages parent node.
+#[cfg(test)]
+fn create_test_pdf_inherited_rotate(rotation: i64) -> Vec<u8> {
+    use lopdf::{Document, Object, ObjectId, dictionary};
+
+    let mut doc = Document::with_version("1.5");
+    let pages_id: ObjectId = doc.new_object_id();
+
+    // Page WITHOUT Rotate — should inherit from parent
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+    });
+
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::from(page_id)],
+            "Count" => 1i64,
+            "Rotate" => rotation,
         }),
     );
 
@@ -290,5 +514,120 @@ mod tests {
 
         // One past the end should fail
         assert!(LopdfBackend::get_page(&doc, count).is_err());
+    }
+
+    // --- page_media_box() tests ---
+
+    #[test]
+    fn media_box_explicit_us_letter() {
+        let pdf_bytes = create_test_pdf(1);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let media_box = LopdfBackend::page_media_box(&doc, &page).unwrap();
+        assert_eq!(media_box, BBox::new(0.0, 0.0, 612.0, 792.0));
+    }
+
+    #[test]
+    fn media_box_inherited_from_parent() {
+        let pdf_bytes = create_test_pdf_inherited_media_box();
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let media_box = LopdfBackend::page_media_box(&doc, &page).unwrap();
+        // Inherited A4 size from parent Pages node
+        assert_eq!(media_box, BBox::new(0.0, 0.0, 595.0, 842.0));
+    }
+
+    #[test]
+    fn media_box_width_height() {
+        let pdf_bytes = create_test_pdf(1);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let media_box = LopdfBackend::page_media_box(&doc, &page).unwrap();
+        assert_eq!(media_box.width(), 612.0);
+        assert_eq!(media_box.height(), 792.0);
+    }
+
+    // --- page_crop_box() tests ---
+
+    #[test]
+    fn crop_box_present() {
+        let pdf_bytes = create_test_pdf_with_crop_box();
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let crop_box = LopdfBackend::page_crop_box(&doc, &page).unwrap();
+        assert_eq!(crop_box, Some(BBox::new(36.0, 36.0, 576.0, 756.0)));
+    }
+
+    #[test]
+    fn crop_box_absent() {
+        let pdf_bytes = create_test_pdf(1);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let crop_box = LopdfBackend::page_crop_box(&doc, &page).unwrap();
+        assert_eq!(crop_box, None);
+    }
+
+    // --- page_rotate() tests ---
+
+    #[test]
+    fn rotate_default_zero() {
+        let pdf_bytes = create_test_pdf(1);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let rotation = LopdfBackend::page_rotate(&doc, &page).unwrap();
+        assert_eq!(rotation, 0);
+    }
+
+    #[test]
+    fn rotate_90() {
+        let pdf_bytes = create_test_pdf_with_rotate(90);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let rotation = LopdfBackend::page_rotate(&doc, &page).unwrap();
+        assert_eq!(rotation, 90);
+    }
+
+    #[test]
+    fn rotate_180() {
+        let pdf_bytes = create_test_pdf_with_rotate(180);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let rotation = LopdfBackend::page_rotate(&doc, &page).unwrap();
+        assert_eq!(rotation, 180);
+    }
+
+    #[test]
+    fn rotate_270() {
+        let pdf_bytes = create_test_pdf_with_rotate(270);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let rotation = LopdfBackend::page_rotate(&doc, &page).unwrap();
+        assert_eq!(rotation, 270);
+    }
+
+    #[test]
+    fn rotate_inherited_from_parent() {
+        let pdf_bytes = create_test_pdf_inherited_rotate(90);
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+        let rotation = LopdfBackend::page_rotate(&doc, &page).unwrap();
+        assert_eq!(rotation, 90);
+    }
+
+    // --- Integration: all page properties together ---
+
+    #[test]
+    fn page_properties_round_trip() {
+        let pdf_bytes = create_test_pdf_with_crop_box();
+        let doc = LopdfBackend::open(&pdf_bytes).unwrap();
+        let page = LopdfBackend::get_page(&doc, 0).unwrap();
+
+        let media_box = LopdfBackend::page_media_box(&doc, &page).unwrap();
+        let crop_box = LopdfBackend::page_crop_box(&doc, &page).unwrap();
+        let rotation = LopdfBackend::page_rotate(&doc, &page).unwrap();
+
+        assert_eq!(media_box, BBox::new(0.0, 0.0, 612.0, 792.0));
+        assert!(crop_box.is_some());
+        assert_eq!(rotation, 0);
     }
 }

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -128,8 +128,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 7,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "page_media_box with inheritance via resolve_inherited helper. page_crop_box reads from page dict only (no inheritance). page_rotate with inheritance, defaults to 0. Helper functions: extract_bbox_from_array, object_to_f64, resolve_inherited."
     },
     {
       "id": "US-008",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -17,6 +17,10 @@
 - LopdfDocument caches page ObjectIds in a Vec for O(1) 0-based index access (lopdf's get_pages returns BTreeMap<u32, ObjectId> with 1-based keys).
 - LopdfDocument.inner() accessor provides read access to the underlying lopdf::Document.
 - Create test PDFs programmatically with lopdf: Document::with_version + add_object with dictionary! macro. Save to Vec<u8> with save_to().
+- resolve_inherited() walks up page tree via /Parent to find inheritable properties (MediaBox, Rotate, etc.).
+- lopdf Object::as_float() returns f32 for both Integer and Real. Use custom object_to_f64() for f64 precision.
+- lopdf Dictionary::get(b"Key") takes byte slice key. Returns Result — Err if key missing.
+- CropBox is NOT inheritable in practice for this library (read from page dict only). MediaBox and Rotate ARE inherited.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 01시 07분 18초 KST
@@ -116,4 +120,19 @@ Started: 2026년  2월 28일 토요일 01시 07분 18초 KST
   - lopdf's Document::load_mem parses PDF from &[u8]; errors are lopdf::Error which must be mapped to BackendError
   - Test PDFs created with lopdf::Document::with_version + dictionary! macro + save_to(&mut Vec<u8>)
   - Stub methods use todo!() for methods that will be implemented in later stories (US-007+)
+---
+
+## 2026-02-28 - US-007
+- What was implemented: lopdf backend page_media_box, page_crop_box, page_rotate with inheritance support
+- Files changed:
+  - crates/pdfplumber-parse/src/lopdf_backend.rs (added 3 helper functions + 3 trait method implementations + 5 test PDF builder functions + 11 tests)
+  - scripts/ralph/prd.json (marked US-007 passes: true)
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - lopdf get_object() auto-dereferences indirect references; as_dict() casts to dictionary
+  - Page tree inheritance: walk /Parent chain for inheritable properties like MediaBox and Rotate
+  - lopdf Object::as_i64() only works for Integer (not Real); Object::as_float() works for both but returns f32
+  - Custom object_to_f64() helper needed for BBox extraction since we use f64 throughout
+  - CropBox is page-level only (no inheritance in this impl); MediaBox and Rotate use inheritance
+  - Test PDFs with inheritance: put property on Pages node, omit from Page node
 ---


### PR DESCRIPTION
## Summary
- Implemented `page_media_box()` with page tree inheritance support (walks /Parent chain)
- Implemented `page_crop_box()` for optional CropBox extraction from page dictionary
- Implemented `page_rotate()` with inheritance and default value of 0
- Added helper functions: `resolve_inherited()`, `extract_bbox_from_array()`, `object_to_f64()`

## Test plan
- [x] 11 new tests covering all acceptance criteria
- [x] Explicit MediaBox on page
- [x] MediaBox inherited from Pages parent node
- [x] CropBox present and absent cases
- [x] Rotate values: 0 (default), 90, 180, 270
- [x] Rotate inherited from parent
- [x] Integration test: all page properties together
- [x] All 378 workspace tests pass
- [x] cargo fmt, clippy, check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)