### PR TITLE
feat: US-012 - ToUnicode CMap parsing - bfchar and bfrange mapping

### DIFF
--- a/crates/pdfplumber-parse/src/cmap.rs
+++ b/crates/pdfplumber-parse/src/cmap.rs
@@ -1,0 +1,537 @@
+//! ToUnicode CMap parser for mapping character codes to Unicode strings.
+//!
+//! Parses CMap data embedded in PDF `/ToUnicode` streams to convert glyph codes
+//! to Unicode text. Supports `beginbfchar`/`endbfchar` (single mappings) and
+//! `beginbfrange`/`endbfrange` (range mappings) with UTF-16BE encoded values.
+
+use std::collections::HashMap;
+
+use crate::error::BackendError;
+
+/// A parsed ToUnicode CMap that maps character codes to Unicode strings.
+///
+/// Character codes are typically 1 or 2 bytes from the PDF font encoding.
+/// Unicode values may be single characters or multi-character strings
+/// (e.g., ligatures like "fi" → "fi").
+#[derive(Debug, Clone)]
+pub struct CMap {
+    /// Mapping from character code to Unicode string.
+    mappings: HashMap<u32, String>,
+}
+
+impl CMap {
+    /// Parse a ToUnicode CMap from its raw byte content.
+    ///
+    /// Extracts `beginbfchar`/`endbfchar` and `beginbfrange`/`endbfrange`
+    /// sections to build the character code → Unicode mapping table.
+    pub fn parse(data: &[u8]) -> Result<Self, BackendError> {
+        let text = String::from_utf8_lossy(data);
+        let mut mappings = HashMap::new();
+
+        // Parse all beginbfchar...endbfchar sections
+        let mut search_from = 0;
+        while let Some(start) = text[search_from..].find("beginbfchar") {
+            let section_start = search_from + start + "beginbfchar".len();
+            if let Some(end) = text[section_start..].find("endbfchar") {
+                let section = &text[section_start..section_start + end];
+                parse_bfchar_section(section, &mut mappings)?;
+                search_from = section_start + end + "endbfchar".len();
+            } else {
+                break;
+            }
+        }
+
+        // Parse all beginbfrange...endbfrange sections
+        search_from = 0;
+        while let Some(start) = text[search_from..].find("beginbfrange") {
+            let section_start = search_from + start + "beginbfrange".len();
+            if let Some(end) = text[section_start..].find("endbfrange") {
+                let section = &text[section_start..section_start + end];
+                parse_bfrange_section(section, &mut mappings)?;
+                search_from = section_start + end + "endbfrange".len();
+            } else {
+                break;
+            }
+        }
+
+        Ok(CMap { mappings })
+    }
+
+    /// Look up the Unicode string for a character code.
+    ///
+    /// Returns `None` if the code has no mapping in this CMap.
+    pub fn lookup(&self, code: u32) -> Option<&str> {
+        self.mappings.get(&code).map(|s| s.as_str())
+    }
+
+    /// Look up the Unicode string for a character code, with fallback.
+    ///
+    /// If no mapping is found, returns U+FFFD (REPLACEMENT CHARACTER).
+    pub fn lookup_or_replacement(&self, code: u32) -> String {
+        self.lookup(code)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "\u{FFFD}".to_string())
+    }
+
+    /// Returns the number of mappings in this CMap.
+    pub fn len(&self) -> usize {
+        self.mappings.len()
+    }
+
+    /// Returns true if this CMap has no mappings.
+    pub fn is_empty(&self) -> bool {
+        self.mappings.is_empty()
+    }
+}
+
+/// Parse a hex string like "0041" into a u32 character code.
+fn parse_hex_code(hex: &str) -> Result<u32, BackendError> {
+    u32::from_str_radix(hex, 16)
+        .map_err(|e| BackendError::Parse(format!("invalid hex code '{hex}': {e}")))
+}
+
+/// Decode a hex string as UTF-16BE bytes into a Unicode string.
+///
+/// The hex string represents UTF-16BE encoded code units. For BMP characters,
+/// this is a single 2-byte value. For supplementary characters, this is a
+/// surrogate pair (4 bytes). For multi-character mappings (ligatures), this
+/// can be multiple 2-byte values.
+fn decode_utf16be_hex(hex: &str) -> Result<String, BackendError> {
+    if hex.len() % 4 != 0 {
+        // Pad to even number of hex digits (groups of 4 for UTF-16 code units)
+        // For 2-digit hex like "41", treat as single-byte padded to "0041"
+        if hex.len() == 2 {
+            let padded = format!("00{hex}");
+            return decode_utf16be_hex(&padded);
+        }
+        return Err(BackendError::Parse(format!(
+            "UTF-16BE hex string must have length divisible by 4, got '{hex}' (len={})",
+            hex.len()
+        )));
+    }
+
+    // Parse hex string into u16 code units
+    let mut code_units = Vec::with_capacity(hex.len() / 4);
+    for chunk in hex.as_bytes().chunks(4) {
+        let chunk_str = std::str::from_utf8(chunk)
+            .map_err(|e| BackendError::Parse(format!("invalid UTF-8 in hex: {e}")))?;
+        let unit = u16::from_str_radix(chunk_str, 16).map_err(|e| {
+            BackendError::Parse(format!("invalid hex in UTF-16BE '{chunk_str}': {e}"))
+        })?;
+        code_units.push(unit);
+    }
+
+    // Decode UTF-16BE code units to String
+    String::from_utf16(&code_units)
+        .map_err(|e| BackendError::Parse(format!("invalid UTF-16BE sequence: {e}")))
+}
+
+/// Extract all `<hex>` tokens from a line of text.
+fn extract_hex_tokens(text: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find('<') {
+        if let Some(end) = rest[start + 1..].find('>') {
+            let hex = &rest[start + 1..start + 1 + end];
+            tokens.push(hex);
+            rest = &rest[start + 1 + end + 1..];
+        } else {
+            break;
+        }
+    }
+    tokens
+}
+
+/// Parse a beginbfchar...endbfchar section.
+///
+/// Each line has format: `<srcCode> <dstUnicode>`
+fn parse_bfchar_section(
+    section: &str,
+    mappings: &mut HashMap<u32, String>,
+) -> Result<(), BackendError> {
+    for line in section.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || !trimmed.contains('<') {
+            continue;
+        }
+
+        let tokens = extract_hex_tokens(trimmed);
+        if tokens.len() >= 2 {
+            let src_code = parse_hex_code(tokens[0])?;
+            let unicode_str = decode_utf16be_hex(tokens[1])?;
+            mappings.insert(src_code, unicode_str);
+        }
+    }
+    Ok(())
+}
+
+/// Parse a beginbfrange...endbfrange section.
+///
+/// Each line has format: `<srcLow> <srcHigh> <dstStart>`
+/// or: `<srcLow> <srcHigh> [<str1> <str2> ...]`
+fn parse_bfrange_section(
+    section: &str,
+    mappings: &mut HashMap<u32, String>,
+) -> Result<(), BackendError> {
+    for line in section.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || !trimmed.contains('<') {
+            continue;
+        }
+
+        // Check if destination is an array: [<hex> <hex> ...]
+        if let Some(bracket_start) = trimmed.find('[') {
+            // Array form: <srcLow> <srcHigh> [<str1> <str2> ...]
+            let before_bracket = &trimmed[..bracket_start];
+            let src_tokens = extract_hex_tokens(before_bracket);
+            if src_tokens.len() < 2 {
+                continue;
+            }
+            let src_low = parse_hex_code(src_tokens[0])?;
+            let src_high = parse_hex_code(src_tokens[1])?;
+
+            // Extract hex tokens from inside the brackets
+            let bracket_end = trimmed.rfind(']').unwrap_or(trimmed.len());
+            let array_content = &trimmed[bracket_start + 1..bracket_end];
+            let dst_tokens = extract_hex_tokens(array_content);
+
+            for (i, dst_hex) in dst_tokens.iter().enumerate() {
+                let code = src_low + i as u32;
+                if code > src_high {
+                    break;
+                }
+                let unicode_str = decode_utf16be_hex(dst_hex)?;
+                mappings.insert(code, unicode_str);
+            }
+        } else {
+            // Standard form: <srcLow> <srcHigh> <dstStart>
+            let tokens = extract_hex_tokens(trimmed);
+            if tokens.len() < 3 {
+                continue;
+            }
+            let src_low = parse_hex_code(tokens[0])?;
+            let src_high = parse_hex_code(tokens[1])?;
+            let dst_start = parse_hex_code(tokens[2])?;
+
+            for offset in 0..=(src_high - src_low) {
+                let code = src_low + offset;
+                let unicode_cp = dst_start + offset;
+                if let Some(ch) = char::from_u32(unicode_cp) {
+                    mappings.insert(code, ch.to_string());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- CMap construction and basic lookup ---
+
+    #[test]
+    fn empty_cmap_returns_none() {
+        let cmap = CMap::parse(b"").unwrap();
+        assert!(cmap.is_empty());
+        assert_eq!(cmap.len(), 0);
+        assert_eq!(cmap.lookup(0x0041), None);
+    }
+
+    #[test]
+    fn lookup_or_replacement_returns_fffd_for_missing() {
+        let cmap = CMap::parse(b"").unwrap();
+        assert_eq!(cmap.lookup_or_replacement(0x0041), "\u{FFFD}");
+    }
+
+    // --- beginbfchar / endbfchar ---
+
+    #[test]
+    fn bfchar_single_mapping() {
+        let data = b"\
+            beginbfchar\n\
+            <0041> <0041>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+    }
+
+    #[test]
+    fn bfchar_multiple_mappings() {
+        let data = b"\
+            beginbfchar\n\
+            <0041> <0041>\n\
+            <0042> <0042>\n\
+            <0043> <0043>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+        assert_eq!(cmap.lookup(0x0042), Some("B"));
+        assert_eq!(cmap.lookup(0x0043), Some("C"));
+        assert_eq!(cmap.len(), 3);
+    }
+
+    #[test]
+    fn bfchar_single_byte_source_code() {
+        // 1-byte source code
+        let data = b"\
+            beginbfchar\n\
+            <41> <0041>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x41), Some("A"));
+    }
+
+    #[test]
+    fn bfchar_remapped_codes() {
+        // Code 0x01 maps to 'A' (0x0041)
+        let data = b"\
+            beginbfchar\n\
+            <01> <0041>\n\
+            <02> <0042>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x01), Some("A"));
+        assert_eq!(cmap.lookup(0x02), Some("B"));
+    }
+
+    #[test]
+    fn bfchar_multi_char_unicode_ligature() {
+        // fi ligature → "fi" (two Unicode characters)
+        let data = b"\
+            beginbfchar\n\
+            <FB01> <00660069>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0xFB01), Some("fi"));
+    }
+
+    #[test]
+    fn bfchar_non_bmp_character() {
+        // U+1F600 (😀) encoded as UTF-16BE surrogate pair: D83D DE00
+        let data = b"\
+            beginbfchar\n\
+            <0001> <D83DDE00>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0001), Some("\u{1F600}"));
+    }
+
+    #[test]
+    fn bfchar_with_surrounding_cmap_boilerplate() {
+        let data = b"\
+            /CIDInit /ProcSet findresource begin\n\
+            12 dict begin\n\
+            begincmap\n\
+            /CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n\
+            /CMapName /Adobe-Identity-UCS def\n\
+            /CMapType 2 def\n\
+            1 begincodespacerange\n\
+            <0000> <FFFF>\n\
+            endcodespacerange\n\
+            2 beginbfchar\n\
+            <0041> <0041>\n\
+            <0042> <0042>\n\
+            endbfchar\n\
+            endcmap\n\
+            CMapName currentdict /CMap defineresource pop\n\
+            end\n\
+            end\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+        assert_eq!(cmap.lookup(0x0042), Some("B"));
+        assert_eq!(cmap.len(), 2);
+    }
+
+    // --- beginbfrange / endbfrange ---
+
+    #[test]
+    fn bfrange_simple_range() {
+        let data = b"\
+            beginbfrange\n\
+            <0041> <0043> <0041>\n\
+            endbfrange\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+        assert_eq!(cmap.lookup(0x0042), Some("B"));
+        assert_eq!(cmap.lookup(0x0043), Some("C"));
+        assert_eq!(cmap.len(), 3);
+    }
+
+    #[test]
+    fn bfrange_offset_mapping() {
+        // Source codes 0x01-0x03 map to U+0041-U+0043
+        let data = b"\
+            beginbfrange\n\
+            <01> <03> <0041>\n\
+            endbfrange\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x01), Some("A"));
+        assert_eq!(cmap.lookup(0x02), Some("B"));
+        assert_eq!(cmap.lookup(0x03), Some("C"));
+    }
+
+    #[test]
+    fn bfrange_single_code_range() {
+        // Range with low == high (single mapping)
+        let data = b"\
+            beginbfrange\n\
+            <0041> <0041> <0061>\n\
+            endbfrange\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("a")); // U+0061 = 'a'
+        assert_eq!(cmap.len(), 1);
+    }
+
+    #[test]
+    fn bfrange_multiple_ranges() {
+        let data = b"\
+            beginbfrange\n\
+            <0041> <0043> <0041>\n\
+            <0061> <0063> <0061>\n\
+            endbfrange\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+        assert_eq!(cmap.lookup(0x0043), Some("C"));
+        assert_eq!(cmap.lookup(0x0061), Some("a"));
+        assert_eq!(cmap.lookup(0x0063), Some("c"));
+        assert_eq!(cmap.len(), 6);
+    }
+
+    #[test]
+    fn bfrange_with_array_destination() {
+        // Range with array of individual Unicode strings
+        let data = b"\
+            beginbfrange\n\
+            <0041> <0043> [<0058> <0059> <005A>]\n\
+            endbfrange\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("X"));
+        assert_eq!(cmap.lookup(0x0042), Some("Y"));
+        assert_eq!(cmap.lookup(0x0043), Some("Z"));
+    }
+
+    // --- Combined bfchar + bfrange ---
+
+    #[test]
+    fn combined_bfchar_and_bfrange() {
+        let data = b"\
+            2 beginbfchar\n\
+            <0001> <0041>\n\
+            <0002> <0042>\n\
+            endbfchar\n\
+            1 beginbfrange\n\
+            <0003> <0005> <0043>\n\
+            endbfrange\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0001), Some("A"));
+        assert_eq!(cmap.lookup(0x0002), Some("B"));
+        assert_eq!(cmap.lookup(0x0003), Some("C"));
+        assert_eq!(cmap.lookup(0x0004), Some("D"));
+        assert_eq!(cmap.lookup(0x0005), Some("E"));
+        assert_eq!(cmap.len(), 5);
+    }
+
+    // --- Multiple bfchar/bfrange sections ---
+
+    #[test]
+    fn multiple_bfchar_sections() {
+        let data = b"\
+            1 beginbfchar\n\
+            <0041> <0041>\n\
+            endbfchar\n\
+            1 beginbfchar\n\
+            <0042> <0042>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+        assert_eq!(cmap.lookup(0x0042), Some("B"));
+        assert_eq!(cmap.len(), 2);
+    }
+
+    // --- UTF-16BE encoding ---
+
+    #[test]
+    fn utf16be_basic_latin() {
+        // ASCII 'A' is 0x0041 in UTF-16BE
+        let data = b"\
+            beginbfchar\n\
+            <41> <0041>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x41), Some("A"));
+    }
+
+    #[test]
+    fn utf16be_cjk_character() {
+        // U+4E2D (中) in UTF-16BE is 4E2D
+        let data = b"\
+            beginbfchar\n\
+            <01> <4E2D>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x01), Some("中"));
+    }
+
+    #[test]
+    fn utf16be_surrogate_pair() {
+        // U+10400 (𐐀) = D801 DC00 in UTF-16BE
+        let data = b"\
+            beginbfchar\n\
+            <01> <D801DC00>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x01), Some("\u{10400}"));
+    }
+
+    // --- Edge cases ---
+
+    #[test]
+    fn whitespace_variations() {
+        // Tabs and extra whitespace
+        let data = b"\
+            beginbfchar\n\
+            \t<0041>\t<0041>\t\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        let data = b"beginbfchar\r\n<0041> <0041>\r\nendbfchar\r\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x0041), Some("A"));
+    }
+
+    #[test]
+    fn missing_mapping_returns_none() {
+        let data = b"\
+            beginbfchar\n\
+            <0041> <0041>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup(0x9999), None);
+    }
+
+    #[test]
+    fn lookup_or_replacement_with_valid_mapping() {
+        let data = b"\
+            beginbfchar\n\
+            <0041> <0041>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup_or_replacement(0x0041), "A");
+    }
+
+    #[test]
+    fn lookup_or_replacement_with_missing_mapping() {
+        let data = b"\
+            beginbfchar\n\
+            <0041> <0041>\n\
+            endbfchar\n";
+        let cmap = CMap::parse(data).unwrap();
+        assert_eq!(cmap.lookup_or_replacement(0x9999), "\u{FFFD}");
+    }
+}

--- a/crates/pdfplumber-parse/src/lib.rs
+++ b/crates/pdfplumber-parse/src/lib.rs
@@ -5,6 +5,7 @@
 //! It depends on pdfplumber-core for shared data types.
 
 pub mod backend;
+pub mod cmap;
 pub mod error;
 pub mod handler;
 pub mod interpreter_state;
@@ -14,6 +15,7 @@ pub mod text_state;
 pub mod tokenizer;
 
 pub use backend::PdfBackend;
+pub use cmap::CMap;
 pub use error::BackendError;
 pub use handler::{CharEvent, ContentHandler, ImageEvent, PaintOp, PathEvent};
 pub use interpreter_state::InterpreterState;

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -222,8 +222,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 12,
-      "passes": false,
-      "notes": "Place CMap parser in pdfplumber-parse. It needs to handle the CMap syntax from PDF spec."
+      "passes": true,
+      "notes": "CMap struct in pdfplumber-parse/cmap.rs. Parses beginbfchar/endbfchar and beginbfrange/endbfrange sections. UTF-16BE decoding with surrogate pair support. Multi-byte source codes (1-2 bytes). Multi-char Unicode mappings (ligatures). Array destination form for bfrange. 24 unit tests."
     },
     {
       "id": "US-013",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -36,6 +36,10 @@
 - Td/TD/T* operate on line_matrix (pre-multiply translation), then copy to text_matrix.
 - advance_text_position() modifies text_matrix only (not line_matrix) — for glyph advance during Tj/TJ.
 - Tm replaces both text_matrix and line_matrix (it does NOT concatenate).
+- CMap::parse(data) -> Result<CMap, BackendError>. CMap::lookup(code) -> Option<&str>. CMap::lookup_or_replacement(code) -> String (returns U+FFFD for missing).
+- CMap parses beginbfchar/endbfchar and beginbfrange/endbfrange sections. Ignores CMap boilerplate (codespacerange, CIDSystemInfo, etc.).
+- UTF-16BE decoding: hex string → u16 code units → String::from_utf16(). Handles surrogate pairs and multi-char mappings (ligatures).
+- bfrange supports both `<low> <high> <start>` (increment) and `<low> <high> [<str1> <str2>...]` (array) forms.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 01시 07분 18초 KST
@@ -232,4 +236,22 @@ Started: 2026년  2월 28일 토요일 01시 07분 18초 KST
   - Quote (') = T* + Tj. Double quote (") = Tw + Tc + ' (sets spacing first)
   - The line_matrix is NOT modified during Tj — only text_matrix advances
   - With scaled text matrix (e.g., 12x), advance_text_position pre-multiplies, so tx=0.6 becomes 7.2 in page space
+---
+
+## 2026-02-28 - US-012
+- What was implemented: ToUnicode CMap parser — parses bfchar/bfrange sections with UTF-16BE decoding for character code → Unicode mapping
+- Files changed:
+  - crates/pdfplumber-parse/src/cmap.rs (new — CMap struct, parse(), lookup(), UTF-16BE decoder, hex token extractor, 24 tests)
+  - crates/pdfplumber-parse/src/lib.rs (added cmap module + CMap export)
+  - scripts/ralph/prd.json (marked US-012 passes: true)
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - CMap format: beginbfchar/endbfchar for single mappings, beginbfrange/endbfrange for range mappings
+  - Source codes are hex-encoded (1-2 bytes), Unicode values are UTF-16BE encoded hex
+  - UTF-16BE surrogate pairs: D800-DBFF (high) followed by DC00-DFFF (low) for supplementary characters
+  - Multi-char Unicode mappings (e.g., ligature <FB01> → <00660069> = "fi") have hex len > 4
+  - bfrange has two forms: `<low> <high> <start>` (auto-increment) and `<low> <high> [<str1>...]` (explicit array)
+  - CMap data is embedded in PDF as text, so String::from_utf8_lossy is safe for parsing keywords
+  - extract_hex_tokens() scans for <...> pairs — simple and robust for CMap syntax
+  - Single-byte source codes (e.g., <41>) are parsed as u32 directly (not padded to 2 bytes)
 ---


### PR DESCRIPTION
## Summary
- Implement ToUnicode CMap parser (`CMap::parse()`) in `pdfplumber-parse` for mapping PDF character codes to Unicode strings
- Support `beginbfchar`/`endbfchar` single mappings and `beginbfrange`/`endbfrange` range mappings
- Handle UTF-16BE encoded Unicode values including surrogate pairs for supplementary characters
- Support multi-byte source codes (1-2 bytes), multi-character mappings (ligatures), and array destination form for bfrange

## Key changes
- New `crates/pdfplumber-parse/src/cmap.rs` — `CMap` struct with `parse()`, `lookup()`, `lookup_or_replacement()`
- UTF-16BE decoder handles BMP characters, surrogate pairs, and multi-character sequences
- 24 unit tests covering bfchar, bfrange, UTF-16BE encoding, edge cases, and real CMap boilerplate

## Test plan
- [x] 24 unit tests for CMap parsing (bfchar/bfrange/UTF-16BE/surrogate pairs/ligatures/edge cases)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 246+ tests)
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)