### PR TITLE
feat: US-019 - Page::extract_words() API + Word type integration

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -35,8 +35,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Implementation already existed from phase 1. All acceptance criteria verified."
     },
     {
       "id": "US-020",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -28,3 +28,17 @@ Started: 2026년  2월 28일 토요일 09시 02분 42초 KST
   - Phase 1 built ahead: words, CJK, geometry, encoding, layout modules were all implemented in phase 1
   - Subsequent US stories in phase 2 may also already be implemented — verify before writing new code
 ---
+
+## 2026-02-28 - US-019: Page::extract_words() API + Word type integration
+- Implementation already existed from phase 1 (built alongside US-017/US-018)
+- Verified all acceptance criteria against existing code:
+  - `Page::extract_words(options: &WordOptions) -> Vec<Word>` at `crates/pdfplumber/src/page.rs:185-187`
+  - Words contain constituent `Char`s via `Word.chars: Vec<Char>`
+  - Default WordOptions: x_tolerance=3.0, y_tolerance=3.0
+  - Integration test at `crates/pdfplumber/tests/page_api_integration.rs:181-185`
+  - Unit tests at `crates/pdfplumber/src/page.rs:302-423` covering: default options, text concatenation, bbox calculation, multiline, custom options, empty page, constituent chars
+- Files: `crates/pdfplumber/src/page.rs`, `crates/pdfplumber-core/src/words.rs`
+- No code changes needed — all quality checks pass (fmt, clippy, tests)
+- **Learnings for future iterations:**
+  - Confirmed phase 1 built ahead pattern continues
+---


### PR DESCRIPTION
## Summary
- Verified US-019 (Page::extract_words() API) was already implemented in phase 1
- Updated PRD to mark US-019 as passing
- Updated progress log with verification details

## Changes
- `scripts/ralph/prd.json`: Set US-019 `passes: true`
- `scripts/ralph/progress.txt`: Added US-019 verification entry

## Verified Acceptance Criteria
- `Page::extract_words(options: &WordOptions) -> Vec<Word>` exists at `crates/pdfplumber/src/page.rs:185-187`
- Words contain constituent `Char`s via `Word.chars: Vec<Char>`
- Default WordOptions matches pdfplumber defaults (x_tolerance=3.0, y_tolerance=3.0)
- Integration test exists at `crates/pdfplumber/tests/page_api_integration.rs`
- Unit tests cover: default options, text concatenation, bbox calculation, multiline, custom options, empty page, constituent chars
- All quality checks pass (fmt, clippy, tests)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)