### PR TITLE
feat: US-020 - CJK word grouping verified from phase 1

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -52,8 +52,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Implementation already existed from phase 1. All acceptance criteria verified."
     },
     {
       "id": "US-021",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -42,3 +42,15 @@ Started: 2026년  2월 28일 토요일 09시 02분 42초 KST
 - **Learnings for future iterations:**
   - Confirmed phase 1 built ahead pattern continues
 ---
+
+## 2026-02-28 - US-020: CJK word grouping - character-width-based tolerance
+- Implementation already existed from phase 1
+- Verified all acceptance criteria against existing code:
+  - CJK detection by Unicode range: `is_cjk()` in `crates/pdfplumber-core/src/text.rs` covers CJK Unified Ideographs, Hiragana, Katakana, Hangul, and more
+  - Character width-based tolerance: `effective_x_tolerance()` in `crates/pdfplumber-core/src/words.rs` uses char width for CJK
+  - Mixed CJK + Latin: `test_japanese_mixed_text`, `test_mixed_cjk_latin_with_gap`, `test_cjk_transition_to_latin_uses_cjk_tolerance`
+  - Vertical writing mode: `test_vertical_text_chinese`, `test_vertical_text_two_columns`, `test_vertical_text_with_gap`
+  - Chinese: `test_chinese_text_grouping`, Japanese: `test_japanese_mixed_text`, Korean: `test_korean_text_grouping`
+- Files: `crates/pdfplumber-core/src/words.rs`, `crates/pdfplumber-core/src/text.rs`
+- No code changes needed — all quality checks pass
+---


### PR DESCRIPTION
## Summary
- Verified US-020 (CJK word grouping - character-width-based tolerance) was already implemented in phase 1
- Updated PRD to mark US-020 as passing
- Updated progress log with verification details

## Verified Acceptance Criteria
- CJK character detection by Unicode range (CJK Unified Ideographs, Hiragana, Katakana, Hangul)
- Character width-based tolerance for CJK characters
- Mixed CJK + Latin text handling
- Vertical writing mode (TextDirection::Ttb/Btt)
- Unit tests: Chinese, Japanese mixed, Korean, vertical text (11 tests)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)