### PR TITLE
feat: US-030 - Edge processing - snap_edges() for parallel edge alignment

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -29,6 +29,6 @@ pub use layout::{
 pub use painting::{Color, DashPattern, ExtGState, FillRule, GraphicsState, PaintedPath};
 pub use path::{Path, PathBuilder, PathSegment};
 pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
-pub use table::{Cell, ExplicitLines, Strategy, Table, TableFinder, TableSettings};
+pub use table::{Cell, ExplicitLines, Strategy, Table, TableFinder, TableSettings, snap_edges};
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber-core/src/table.rs
+++ b/crates/pdfplumber-core/src/table.rs
@@ -116,6 +116,87 @@ pub struct Table {
     pub columns: Vec<Vec<Cell>>,
 }
 
+/// Snap nearby parallel edges to aligned positions.
+///
+/// Groups edges by orientation and clusters them along the perpendicular axis.
+/// For horizontal edges, clusters by y-coordinate within `snap_y_tolerance`.
+/// For vertical edges, clusters by x-coordinate within `snap_x_tolerance`.
+/// Clustered edges have their perpendicular coordinates replaced with the cluster mean.
+/// Diagonal edges pass through unchanged.
+///
+/// This does **not** merge edges — it only aligns their positions.
+pub fn snap_edges(edges: Vec<Edge>, snap_x_tolerance: f64, snap_y_tolerance: f64) -> Vec<Edge> {
+    use crate::geometry::Orientation;
+
+    let mut result = Vec::with_capacity(edges.len());
+    let mut horizontals: Vec<Edge> = Vec::new();
+    let mut verticals: Vec<Edge> = Vec::new();
+
+    for edge in edges {
+        match edge.orientation {
+            Orientation::Horizontal => horizontals.push(edge),
+            Orientation::Vertical => verticals.push(edge),
+            Orientation::Diagonal => result.push(edge),
+        }
+    }
+
+    // Snap horizontal edges: cluster by y-coordinate (top/bottom)
+    snap_group(
+        &mut horizontals,
+        snap_y_tolerance,
+        |e| e.top,
+        |e, v| {
+            e.top = v;
+            e.bottom = v;
+        },
+    );
+    result.extend(horizontals);
+
+    // Snap vertical edges: cluster by x-coordinate (x0/x1)
+    snap_group(
+        &mut verticals,
+        snap_x_tolerance,
+        |e| e.x0,
+        |e, v| {
+            e.x0 = v;
+            e.x1 = v;
+        },
+    );
+    result.extend(verticals);
+
+    result
+}
+
+/// Cluster edges along a single axis and snap each cluster to its mean.
+fn snap_group<F, G>(edges: &mut [Edge], tolerance: f64, key: F, mut set: G)
+where
+    F: Fn(&Edge) -> f64,
+    G: FnMut(&mut Edge, f64),
+{
+    if edges.is_empty() {
+        return;
+    }
+
+    // Sort by the perpendicular coordinate
+    edges.sort_by(|a, b| key(a).partial_cmp(&key(b)).unwrap());
+
+    // Build clusters of consecutive edges within tolerance
+    let mut cluster_start = 0;
+    for i in 1..=edges.len() {
+        let end_of_cluster =
+            i == edges.len() || (key(&edges[i]) - key(&edges[cluster_start])).abs() > tolerance;
+        if end_of_cluster {
+            // Compute mean of the cluster
+            let sum: f64 = (cluster_start..i).map(|j| key(&edges[j])).sum();
+            let mean = sum / (i - cluster_start) as f64;
+            for edge in &mut edges[cluster_start..i] {
+                set(edge, mean);
+            }
+            cluster_start = i;
+        }
+    }
+}
+
 /// Orchestrator for the table detection pipeline.
 ///
 /// Takes edges (and optionally words/chars) and settings, then runs
@@ -431,5 +512,316 @@ mod tests {
         };
         assert!(lines.horizontal_lines.is_empty());
         assert!(lines.vertical_lines.is_empty());
+    }
+
+    // --- snap_edges tests ---
+
+    fn make_h_edge(x0: f64, y: f64, x1: f64) -> Edge {
+        Edge {
+            x0,
+            top: y,
+            x1,
+            bottom: y,
+            orientation: Orientation::Horizontal,
+            source: crate::edges::EdgeSource::Line,
+        }
+    }
+
+    fn make_v_edge(x: f64, top: f64, bottom: f64) -> Edge {
+        Edge {
+            x0: x,
+            top,
+            x1: x,
+            bottom,
+            orientation: Orientation::Vertical,
+            source: crate::edges::EdgeSource::Line,
+        }
+    }
+
+    fn assert_approx(a: f64, b: f64) {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "expected {b}, got {a}, diff={}",
+            (a - b).abs()
+        );
+    }
+
+    #[test]
+    fn test_snap_edges_empty() {
+        let result = snap_edges(Vec::new(), 3.0, 3.0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_snap_nearby_horizontal_lines() {
+        // Two horizontal edges at y=50.0 and y=51.5 (within tolerance 3.0)
+        // Should snap to mean = 50.75
+        let edges = vec![make_h_edge(0.0, 50.0, 100.0), make_h_edge(0.0, 51.5, 100.0)];
+        let result = snap_edges(edges, 3.0, 3.0);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        assert_eq!(horizontals.len(), 2);
+        assert_approx(horizontals[0].top, 50.75);
+        assert_approx(horizontals[0].bottom, 50.75);
+        assert_approx(horizontals[1].top, 50.75);
+        assert_approx(horizontals[1].bottom, 50.75);
+    }
+
+    #[test]
+    fn test_snap_nearby_vertical_lines() {
+        // Two vertical edges at x=100.0 and x=101.0 (within tolerance 3.0)
+        // Should snap to mean = 100.5
+        let edges = vec![
+            make_v_edge(100.0, 0.0, 200.0),
+            make_v_edge(101.0, 0.0, 200.0),
+        ];
+        let result = snap_edges(edges, 3.0, 3.0);
+
+        let verticals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Vertical)
+            .collect();
+        assert_eq!(verticals.len(), 2);
+        assert_approx(verticals[0].x0, 100.5);
+        assert_approx(verticals[0].x1, 100.5);
+        assert_approx(verticals[1].x0, 100.5);
+        assert_approx(verticals[1].x1, 100.5);
+    }
+
+    #[test]
+    fn test_snap_edges_far_apart_remain_unchanged() {
+        // Two horizontal edges at y=50.0 and y=100.0 (far apart, beyond tolerance 3.0)
+        let edges = vec![
+            make_h_edge(0.0, 50.0, 100.0),
+            make_h_edge(0.0, 100.0, 100.0),
+        ];
+        let result = snap_edges(edges, 3.0, 3.0);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        assert_eq!(horizontals.len(), 2);
+        // They should remain at their original positions
+        let mut ys: Vec<f64> = horizontals.iter().map(|e| e.top).collect();
+        ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_approx(ys[0], 50.0);
+        assert_approx(ys[1], 100.0);
+    }
+
+    #[test]
+    fn test_snap_edges_separate_x_y_tolerance() {
+        // Horizontal edges within 2.0 of each other, snap_y_tolerance=1.0 (NOT within)
+        // Should NOT snap
+        let edges = vec![make_h_edge(0.0, 50.0, 100.0), make_h_edge(0.0, 52.0, 100.0)];
+        let result = snap_edges(edges, 3.0, 1.0);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        let mut ys: Vec<f64> = horizontals.iter().map(|e| e.top).collect();
+        ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_approx(ys[0], 50.0);
+        assert_approx(ys[1], 52.0);
+    }
+
+    #[test]
+    fn test_snap_edges_separate_x_tolerance() {
+        // Vertical edges within 2.0 of each other, snap_x_tolerance=1.0 (NOT within)
+        // Should NOT snap
+        let edges = vec![
+            make_v_edge(100.0, 0.0, 200.0),
+            make_v_edge(102.0, 0.0, 200.0),
+        ];
+        let result = snap_edges(edges, 1.0, 3.0);
+
+        let verticals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Vertical)
+            .collect();
+        let mut xs: Vec<f64> = verticals.iter().map(|e| e.x0).collect();
+        xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_approx(xs[0], 100.0);
+        assert_approx(xs[1], 102.0);
+    }
+
+    #[test]
+    fn test_snap_edges_does_not_merge() {
+        // Three horizontal edges within tolerance should snap but remain 3 separate edges
+        let edges = vec![
+            make_h_edge(0.0, 50.0, 100.0),
+            make_h_edge(10.0, 51.0, 90.0),
+            make_h_edge(20.0, 50.5, 80.0),
+        ];
+        let result = snap_edges(edges, 3.0, 3.0);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        // Still 3 edges - snap does not merge
+        assert_eq!(horizontals.len(), 3);
+        // All snapped to mean of 50.0, 51.0, 50.5 = 50.5
+        for h in &horizontals {
+            assert_approx(h.top, 50.5);
+            assert_approx(h.bottom, 50.5);
+        }
+    }
+
+    #[test]
+    fn test_snap_edges_preserves_along_axis_coords() {
+        // Snapping horizontal edges should only change y, not x
+        let edges = vec![
+            make_h_edge(10.0, 50.0, 200.0),
+            make_h_edge(30.0, 51.0, 180.0),
+        ];
+        let result = snap_edges(edges, 3.0, 3.0);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        // x-coordinates should be unchanged
+        let mut found_10 = false;
+        let mut found_30 = false;
+        for h in &horizontals {
+            if (h.x0 - 10.0).abs() < 1e-6 {
+                assert_approx(h.x1, 200.0);
+                found_10 = true;
+            }
+            if (h.x0 - 30.0).abs() < 1e-6 {
+                assert_approx(h.x1, 180.0);
+                found_30 = true;
+            }
+        }
+        assert!(found_10 && found_30, "x-coordinates should be preserved");
+    }
+
+    #[test]
+    fn test_snap_edges_mixed_orientations() {
+        // Mix of horizontal and vertical edges, each group snaps independently
+        let edges = vec![
+            make_h_edge(0.0, 50.0, 100.0),
+            make_h_edge(0.0, 51.0, 100.0),
+            make_v_edge(200.0, 0.0, 100.0),
+            make_v_edge(201.0, 0.0, 100.0),
+        ];
+        let result = snap_edges(edges, 3.0, 3.0);
+        assert_eq!(result.len(), 4);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        let verticals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Vertical)
+            .collect();
+
+        // Horizontal snapped to mean(50, 51) = 50.5
+        for h in &horizontals {
+            assert_approx(h.top, 50.5);
+        }
+        // Vertical snapped to mean(200, 201) = 200.5
+        for v in &verticals {
+            assert_approx(v.x0, 200.5);
+        }
+    }
+
+    #[test]
+    fn test_snap_edges_multiple_clusters() {
+        // Three groups of horizontal edges, well separated
+        let edges = vec![
+            make_h_edge(0.0, 10.0, 100.0),
+            make_h_edge(0.0, 11.0, 100.0),
+            // gap
+            make_h_edge(0.0, 50.0, 100.0),
+            make_h_edge(0.0, 51.0, 100.0),
+            // gap
+            make_h_edge(0.0, 100.0, 100.0),
+            make_h_edge(0.0, 101.0, 100.0),
+        ];
+        let result = snap_edges(edges, 3.0, 3.0);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        assert_eq!(horizontals.len(), 6);
+
+        let mut ys: Vec<f64> = horizontals.iter().map(|e| e.top).collect();
+        ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // Cluster 1: mean(10, 11) = 10.5
+        assert_approx(ys[0], 10.5);
+        assert_approx(ys[1], 10.5);
+        // Cluster 2: mean(50, 51) = 50.5
+        assert_approx(ys[2], 50.5);
+        assert_approx(ys[3], 50.5);
+        // Cluster 3: mean(100, 101) = 100.5
+        assert_approx(ys[4], 100.5);
+        assert_approx(ys[5], 100.5);
+    }
+
+    #[test]
+    fn test_snap_edges_single_edge_unchanged() {
+        let edges = vec![make_h_edge(0.0, 50.0, 100.0)];
+        let result = snap_edges(edges, 3.0, 3.0);
+        assert_eq!(result.len(), 1);
+        assert_approx(result[0].top, 50.0);
+        assert_approx(result[0].bottom, 50.0);
+    }
+
+    #[test]
+    fn test_snap_edges_diagonal_passed_through() {
+        let edges = vec![
+            Edge {
+                x0: 0.0,
+                top: 0.0,
+                x1: 100.0,
+                bottom: 100.0,
+                orientation: Orientation::Diagonal,
+                source: crate::edges::EdgeSource::Curve,
+            },
+            make_h_edge(0.0, 50.0, 100.0),
+        ];
+        let result = snap_edges(edges, 3.0, 3.0);
+        assert_eq!(result.len(), 2);
+
+        let diagonals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Diagonal)
+            .collect();
+        assert_eq!(diagonals.len(), 1);
+        // Diagonal edge unchanged
+        assert_approx(diagonals[0].x0, 0.0);
+        assert_approx(diagonals[0].top, 0.0);
+        assert_approx(diagonals[0].x1, 100.0);
+        assert_approx(diagonals[0].bottom, 100.0);
+    }
+
+    #[test]
+    fn test_snap_edges_zero_tolerance() {
+        // With zero tolerance, only exact matches snap
+        let edges = vec![
+            make_h_edge(0.0, 50.0, 100.0),
+            make_h_edge(0.0, 50.0, 100.0), // exact same y
+            make_h_edge(0.0, 50.1, 100.0), // different y
+        ];
+        let result = snap_edges(edges, 0.0, 0.0);
+
+        let horizontals: Vec<&Edge> = result
+            .iter()
+            .filter(|e| e.orientation == Orientation::Horizontal)
+            .collect();
+        assert_eq!(horizontals.len(), 3);
+        let mut ys: Vec<f64> = horizontals.iter().map(|e| e.top).collect();
+        ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_approx(ys[0], 50.0);
+        assert_approx(ys[1], 50.0);
+        assert_approx(ys[2], 50.1);
     }
 }

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -15,14 +15,14 @@ mod pdf;
 pub use page::Page;
 pub use pdf::Pdf;
 pub use pdfplumber_core::{
-    BBox, Char, Color, Ctm, Curve, DashPattern, Edge, EdgeSource, EncodingResolver, ExtGState,
-    ExtractOptions, ExtractResult, ExtractWarning, FillRule, FontEncoding, GraphicsState, Image,
-    ImageMetadata, Line, LineOrientation, Orientation, PaintedPath, Path, PathBuilder, PathSegment,
-    PdfError, Point, Rect, StandardEncoding, Strategy, Table, TableFinder, TableSettings, TextBlock,
-    TextDirection, TextLine, TextOptions, Word, WordExtractor, WordOptions, Cell, ExplicitLines,
-    blocks_to_text, cluster_lines_into_blocks,
+    BBox, Cell, Char, Color, Ctm, Curve, DashPattern, Edge, EdgeSource, EncodingResolver,
+    ExplicitLines, ExtGState, ExtractOptions, ExtractResult, ExtractWarning, FillRule,
+    FontEncoding, GraphicsState, Image, ImageMetadata, Line, LineOrientation, Orientation,
+    PaintedPath, Path, PathBuilder, PathSegment, PdfError, Point, Rect, StandardEncoding, Strategy,
+    Table, TableFinder, TableSettings, TextBlock, TextDirection, TextLine, TextOptions, Word,
+    WordExtractor, WordOptions, blocks_to_text, cluster_lines_into_blocks,
     cluster_words_into_lines, derive_edges, edge_from_curve, edge_from_line, edges_from_rect,
-    extract_shapes, image_from_ctm, is_cjk, is_cjk_text, sort_blocks_reading_order,
+    extract_shapes, image_from_ctm, is_cjk, is_cjk_text, snap_edges, sort_blocks_reading_order,
     split_lines_at_columns, words_to_text,
 };
 pub use pdfplumber_parse::{

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -37,7 +37,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -11,6 +11,8 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
 - `Edge` struct has x0/top/x1/bottom/orientation/source fields
 - `derive_edges()` converts Lines+Rects+Curves to Vec<Edge>
 - Clippy: use `#[derive(Default)]` with `#[default]` variant instead of manual `impl Default` for enums
+- `snap_edges()` function lives in `table.rs` as a public standalone function; uses `snap_group()` helper for clustering
+- Edge processing helpers: `make_h_edge(x0, y, x1)` and `make_v_edge(x, top, bottom)` in test module for concise test construction
 
 ---
 
@@ -23,4 +25,16 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - Strategy defaults to Lattice, all tolerances default to 3.0
   - TableFinder::find_tables() is a placeholder returning empty Vec, will be wired up in US-030 through US-036
   - Clippy enforces `#[derive(Default)]` for enums on Rust edition 2024
+---
+
+## 2026-02-28 - US-030
+- Implemented `snap_edges()` for parallel edge alignment and `snap_group()` clustering helper
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - `snap_edges(edges, snap_x_tolerance, snap_y_tolerance)` takes owned Vec<Edge> and returns Vec<Edge>
+  - Horizontal edges cluster by y-coord (top/bottom), vertical edges cluster by x-coord (x0/x1)
+  - Clustering algorithm: sort by perpendicular axis, group consecutive within tolerance, replace with mean
+  - Diagonal edges pass through unchanged
+  - Snap only aligns positions, does NOT merge edges (merge is US-031 join_edge_group)
 ---


### PR DESCRIPTION
## Summary
- Implement `snap_edges()` function that aligns nearby parallel edges to reduce noise from slight coordinate variations in PDFs
- Horizontal edges are clustered by y-coordinate within `snap_y_tolerance`, vertical edges by x-coordinate within `snap_x_tolerance`
- Clustered edges have perpendicular coordinates replaced with cluster mean; diagonal edges pass through unchanged
- Added helper `snap_group()` for generic axis-based clustering

## Test plan
- [x] Test snap nearby horizontal lines (cluster to mean)
- [x] Test snap nearby vertical lines (cluster to mean)
- [x] Test edges far apart remain unchanged
- [x] Test separate snap_x_tolerance and snap_y_tolerance
- [x] Test snap does not merge edges (count preserved)
- [x] Test along-axis coordinates preserved
- [x] Test mixed orientations snap independently
- [x] Test multiple clusters
- [x] Test single edge unchanged
- [x] Test diagonal edges pass through
- [x] Test zero tolerance
- [x] All quality checks pass (fmt, clippy, test, check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)