### PR TITLE
feat: US-031 - Edge processing - join_edge_group() for segment merging

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -29,6 +29,8 @@ pub use layout::{
 pub use painting::{Color, DashPattern, ExtGState, FillRule, GraphicsState, PaintedPath};
 pub use path::{Path, PathBuilder, PathSegment};
 pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
-pub use table::{Cell, ExplicitLines, Strategy, Table, TableFinder, TableSettings, snap_edges};
+pub use table::{
+    Cell, ExplicitLines, Strategy, Table, TableFinder, TableSettings, join_edge_group, snap_edges,
+};
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -22,8 +22,8 @@ pub use pdfplumber_core::{
     Table, TableFinder, TableSettings, TextBlock, TextDirection, TextLine, TextOptions, Word,
     WordExtractor, WordOptions, blocks_to_text, cluster_lines_into_blocks,
     cluster_words_into_lines, derive_edges, edge_from_curve, edge_from_line, edges_from_rect,
-    extract_shapes, image_from_ctm, is_cjk, is_cjk_text, snap_edges, sort_blocks_reading_order,
-    split_lines_at_columns, words_to_text,
+    extract_shapes, image_from_ctm, is_cjk, is_cjk_text, join_edge_group, snap_edges,
+    sort_blocks_reading_order, split_lines_at_columns, words_to_text,
 };
 pub use pdfplumber_parse::{
     self, CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, LopdfPage,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -55,7 +55,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -38,3 +38,14 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - Diagonal edges pass through unchanged
   - Snap only aligns positions, does NOT merge edges (merge is US-031 join_edge_group)
 ---
+
+## 2026-02-28 - US-031
+- Implemented `join_edge_group()` for merging overlapping/adjacent collinear edge segments
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - `join_edge_group(edges, join_x_tolerance, join_y_tolerance)` takes owned Vec<Edge> and returns Vec<Edge>
+  - Uses `join_collinear()` helper: groups by collinear key (y for horizontal, x for vertical), sorts by span start, merges when gap ≤ tolerance
+  - Chain merging works naturally: sorted segments extend current span greedily
+  - Diagonal edges pass through unchanged (consistent with snap_edges)
+---


### PR DESCRIPTION
## Summary
- Implemented `join_edge_group()` that merges overlapping or adjacent collinear edge segments into single edges
- Uses `join_collinear()` helper: groups edges by collinear key, sorts by span start, merges when gap ≤ tolerance
- Separate `join_x_tolerance` and `join_y_tolerance` for fine-grained control
- Diagonal edges pass through unchanged

## Test plan
- [x] Two overlapping edges merge into one
- [x] Adjacent edges within tolerance merge
- [x] Distant edges don't merge
- [x] Chain of 3 segments merges into one
- [x] Vertical edge merging
- [x] Mixed orientations join independently
- [x] Separate x/y tolerance works correctly
- [x] Diagonal edges pass through unchanged
- [x] Empty input returns empty
- [x] Single edge unchanged
- [x] cargo fmt --all -- --check passes
- [x] cargo clippy --workspace -- -D warnings passes
- [x] cargo test --workspace passes
- [x] cargo check --workspace passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)