### PR TITLE
feat: US-033 - Cell construction - intersections_to_cells()

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use path::{Path, PathBuilder, PathSegment};
 pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
 pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableSettings,
-    edges_to_intersections, join_edge_group, snap_edges,
+    edges_to_intersections, intersections_to_cells, join_edge_group, snap_edges,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -23,8 +23,8 @@ pub use pdfplumber_core::{
     TextLine, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text,
     cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, edge_from_curve,
     edge_from_line, edges_from_rect, edges_to_intersections, extract_shapes, image_from_ctm,
-    is_cjk, is_cjk_text, join_edge_group, snap_edges, sort_blocks_reading_order,
-    split_lines_at_columns, words_to_text,
+    intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
+    sort_blocks_reading_order, split_lines_at_columns, words_to_text,
 };
 pub use pdfplumber_parse::{
     self, CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, LopdfPage,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -91,7 +91,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -17,6 +17,8 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
 - `Intersection` struct has `x: f64` and `y: f64` fields
 - Intersection detection: checks H-edge y within V-edge y-span and V-edge x within H-edge x-span (with tolerance)
 - Deduplication: intersections at the same point (within 1e-9) are deduplicated via sort+dedup_by
+- `intersections_to_cells(intersections: &[Intersection]) -> Vec<Cell>` constructs cells from a grid of intersection points
+- Cell construction: collects unique x/y coords, sorts them, checks all 4 corners for each adjacent pair
 
 ---
 
@@ -65,4 +67,17 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - Results are sorted by (x, y) and deduplicated for points at the same location (within 1e-9)
   - Diagonal edges are filtered out (only H×V crossings matter)
   - 13 tests covering: empty input, cross, T-intersection, L-corner, parallel (no intersection), tolerance-based, grid 2x2, diagonal ignored, multiple edges, separate x/y tolerance, deduplication
+---
+
+## 2026-02-28 - US-033
+- Implemented `intersections_to_cells()` for constructing rectangular cells from intersection points
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - `intersections_to_cells(intersections: &[Intersection]) -> Vec<Cell>` takes borrowed slice
+  - Algorithm: collect unique x/y coords → sort → check all 4 corners for each adjacent (xi,xi+1)×(yi,yi+1) pair
+  - Deduplication of coordinates uses 1e-9 tolerance (same as intersection dedup)
+  - Missing corners are skipped gracefully (no panics)
+  - All cells have `text: None` — text extraction is a separate step (US-036)
+  - 10 tests covering: empty, 2x2 grid, 3x3 grid, missing corner, irregular grid, partial grid, single point, collinear points, 4x3 grid, text is None
 ---


### PR DESCRIPTION
## Summary
- Implement `intersections_to_cells()` that constructs rectangular cells from a grid of intersection points
- Groups intersection points into unique x/y coordinates, sorts them, and checks all 4 corners for each adjacent pair
- Returns `Vec<Cell>` with proper bounding boxes; missing corners are skipped gracefully

## Test plan
- [x] Empty intersections → empty result
- [x] 2x2 grid → 1 cell
- [x] 3x3 grid → 4 cells
- [x] Missing corner → no cell formed
- [x] Irregular grid with missing center
- [x] Partial grid with valid cells
- [x] Single point → no cells
- [x] Collinear points → no cells
- [x] 4x3 grid → 6 cells
- [x] All cells have text = None
- [x] All quality checks pass (fmt, clippy, test, check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)