### PR TITLE
feat: US-034 - Table grouping - cells_to_tables()

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use path::{Path, PathBuilder, PathSegment};
 pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
 pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableSettings,
-    edges_to_intersections, intersections_to_cells, join_edge_group, snap_edges,
+    cells_to_tables, edges_to_intersections, intersections_to_cells, join_edge_group, snap_edges,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -20,7 +20,7 @@ pub use pdfplumber_core::{
     FontEncoding, GraphicsState, Image, ImageMetadata, Intersection, Line, LineOrientation,
     Orientation, PaintedPath, Path, PathBuilder, PathSegment, PdfError, Point, Rect,
     StandardEncoding, Strategy, Table, TableFinder, TableSettings, TextBlock, TextDirection,
-    TextLine, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text,
+    TextLine, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text, cells_to_tables,
     cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, edge_from_curve,
     edge_from_line, edges_from_rect, edges_to_intersections, extract_shapes, image_from_ctm,
     intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -110,7 +110,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 6,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -19,6 +19,8 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
 - Deduplication: intersections at the same point (within 1e-9) are deduplicated via sort+dedup_by
 - `intersections_to_cells(intersections: &[Intersection]) -> Vec<Cell>` constructs cells from a grid of intersection points
 - Cell construction: collects unique x/y coords, sorts them, checks all 4 corners for each adjacent pair
+- `cells_to_tables(cells: Vec<Cell>) -> Vec<Table>` groups adjacent cells into tables using union-find
+- Table grouping: `cells_share_edge()` checks shared boundaries, `float_key()` converts f64→i64 for BTreeMap grouping
 
 ---
 
@@ -80,4 +82,19 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - Missing corners are skipped gracefully (no panics)
   - All cells have `text: None` — text extraction is a separate step (US-036)
   - 10 tests covering: empty, 2x2 grid, 3x3 grid, missing corner, irregular grid, partial grid, single point, collinear points, 4x3 grid, text is None
+---
+
+## 2026-02-28 - US-034
+- Implemented `cells_to_tables()` for grouping adjacent cells into distinct tables
+- Added `cells_share_edge()` helper and `float_key()` utility for coordinate grouping
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - `cells_to_tables(cells: Vec<Cell>) -> Vec<Table>` takes owned Vec, returns sorted Vec<Table>
+  - Uses union-find algorithm to group cells sharing edges (vertical or horizontal boundary with overlapping ranges)
+  - `cells_share_edge()` checks for shared vertical boundary (x1==x0 with overlapping y) or shared horizontal boundary (bottom==top with overlapping x)
+  - Rows grouped by `float_key(top)` (multiply by 1000, round to i64) using BTreeMap for sorted order
+  - Columns grouped by `float_key(x0)` similarly
+  - Tables sorted by (top, x0) for deterministic output
+  - 9 tests covering: empty, single cell, 2x2 grid, row ordering, column ordering, two separate tables, 3x3 grid, single row, single column
 ---


### PR DESCRIPTION
## Summary
- Implement `cells_to_tables()` that groups adjacent cells into distinct tables using a union-find algorithm
- Cells sharing edges (vertical or horizontal boundaries with overlapping ranges) are grouped into the same table
- Each table gets a union bbox, organized rows (top-to-bottom, left-to-right) and columns (left-to-right, top-to-bottom)
- Added helper functions: `cells_share_edge()` for adjacency detection, `float_key()` for coordinate grouping

## Test plan
- [x] Empty input returns empty output
- [x] Single cell forms single table
- [x] 2x2 grid forms one table with correct rows/columns
- [x] Row ordering: top-to-bottom, left-to-right
- [x] Column ordering: left-to-right, top-to-bottom
- [x] Two separate tables (no shared edges) detected as distinct
- [x] 3x3 grid: 9 cells, 3 rows, 3 columns
- [x] Single row: 1 row, multiple columns
- [x] Single column: multiple rows, 1 column
- [x] All quality checks pass (fmt, clippy, test, check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)