### PR TITLE
feat: US-035 - Lattice strategy - complete line-based table detection

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -128,7 +128,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 7,
-      "passes": false,
+      "passes": true,
       "notes": "This is the primary table detection method."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -21,6 +21,9 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
 - Cell construction: collects unique x/y coords, sorts them, checks all 4 corners for each adjacent pair
 - `cells_to_tables(cells: Vec<Cell>) -> Vec<Table>` groups adjacent cells into tables using union-find
 - Table grouping: `cells_share_edge()` checks shared boundaries, `float_key()` converts f64→i64 for BTreeMap grouping
+- `edge_length(edge)` computes length via Euclidean distance (sqrt(dx²+dy²))
+- `TableFinder::find_tables()` runs full pipeline: filter by strategy → filter by min_length → snap → join → intersections → cells → tables
+- LatticeStrict filters edges by `EdgeSource::Line` only; Lattice uses all edge sources
 
 ---
 
@@ -97,4 +100,18 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - Columns grouped by `float_key(x0)` similarly
   - Tables sorted by (top, x0) for deterministic output
   - 9 tests covering: empty, single cell, 2x2 grid, row ordering, column ordering, two separate tables, 3x3 grid, single row, single column
+---
+
+## 2026-02-28 - US-035
+- Implemented full Lattice pipeline in `TableFinder::find_tables()`: filter by strategy → filter by min_length → snap → join → intersections → cells → tables
+- Added `edge_length()` helper for computing edge length via Euclidean distance
+- LatticeStrict mode filters to `EdgeSource::Line` only (excludes rect edges)
+- Lattice mode uses all edge sources including rect edges
+- Files changed: `crates/pdfplumber-core/src/table.rs`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - Pipeline is straightforward chaining of existing functions: snap_edges → join_edge_group → edges_to_intersections → intersections_to_cells → cells_to_tables
+  - Edge source filtering for LatticeStrict uses the `EdgeSource` enum discriminant
+  - `edge_length()` uses Euclidean distance which works for all orientations (H, V, diagonal)
+  - 10 tests covering: simple bordered table, rect edges, strict mode, strict with lines, edge min length filtering, full pipeline snap+join, empty edges, no intersections, strict mixed edges
 ---


### PR DESCRIPTION
## Summary
- Wired the full Lattice pipeline in `TableFinder::find_tables()`: filter edges by strategy → filter by min_length → snap → join → intersections → cells → tables
- **Lattice** strategy uses all edges (lines + rect edges)
- **LatticeStrict** strategy uses only line-sourced edges (no rect edges)
- Added `edge_length()` helper using Euclidean distance
- 10 new tests covering: simple bordered table, rect edges, strict mode, edge min length filtering, full pipeline with snap+join, empty/no-intersection cases

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — all 764 tests pass
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)