### PR TITLE
feat: US-036 - Cell text extraction

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -31,7 +31,8 @@ pub use path::{Path, PathBuilder, PathSegment};
 pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
 pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableSettings,
-    cells_to_tables, edges_to_intersections, intersections_to_cells, join_edge_group, snap_edges,
+    cells_to_tables, edges_to_intersections, extract_text_for_cells, intersections_to_cells,
+    join_edge_group, snap_edges,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -22,9 +22,9 @@ pub use pdfplumber_core::{
     StandardEncoding, Strategy, Table, TableFinder, TableSettings, TextBlock, TextDirection,
     TextLine, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text, cells_to_tables,
     cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, edge_from_curve,
-    edge_from_line, edges_from_rect, edges_to_intersections, extract_shapes, image_from_ctm,
-    intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
-    sort_blocks_reading_order, split_lines_at_columns, words_to_text,
+    edge_from_line, edges_from_rect, edges_to_intersections, extract_shapes,
+    extract_text_for_cells, image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text,
+    join_edge_group, snap_edges, sort_blocks_reading_order, split_lines_at_columns, words_to_text,
 };
 pub use pdfplumber_parse::{
     self, CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, LopdfPage,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -146,7 +146,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 8,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -24,6 +24,9 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
 - `edge_length(edge)` computes length via Euclidean distance (sqrt(dx²+dy²))
 - `TableFinder::find_tables()` runs full pipeline: filter by strategy → filter by min_length → snap → join → intersections → cells → tables
 - LatticeStrict filters edges by `EdgeSource::Line` only; Lattice uses all edge sources
+- `extract_text_for_cells(cells, chars)` populates cell text using center-point containment + WordExtractor
+- Center-point containment: char bbox center (cx, cy) must fall within cell bbox
+- Text assembly: chars → WordExtractor → group words into lines by y-tolerance → join with spaces/newlines
 
 ---
 
@@ -114,4 +117,19 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - Edge source filtering for LatticeStrict uses the `EdgeSource` enum discriminant
   - `edge_length()` uses Euclidean distance which works for all orientations (H, V, diagonal)
   - 10 tests covering: simple bordered table, rect edges, strict mode, strict with lines, edge min length filtering, full pipeline snap+join, empty edges, no intersections, strict mixed edges
+---
+
+## 2026-02-28 - US-036
+- Implemented `extract_text_for_cells()` for extracting text content within detected table cells
+- Uses center-point containment: char bbox center (cx, cy) must be within cell bbox
+- Groups chars into words via `WordExtractor`, then groups words into lines by y-proximity
+- Joins words within a line with spaces, lines with newlines
+- Cells with no matching chars get `text = None`
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - `extract_text_for_cells(cells: &mut [Cell], chars: &[Char])` takes mutable slice to modify in place
+  - Uses `WordOptions::default()` for word grouping (x_tolerance=3, y_tolerance=3)
+  - Line grouping uses same y_tolerance as word grouping for consistency
+  - 10 tests covering: single word, empty cell, chars outside, center-point containment (in/out), multiple words, multiple lines, two cells, no cells, mixed empty/populated
 ---


### PR DESCRIPTION
## Summary
- Implement `extract_text_for_cells()` function that extracts text content for detected table cells
- Uses center-point containment: a character is assigned to a cell if its bbox center falls within the cell bbox
- Groups characters into words using `WordExtractor`, then groups words into lines by y-proximity
- Joins words within a line with spaces, lines with newlines; empty cells get `text = None`

## Test plan
- [x] Single word in cell
- [x] Empty cell (no chars)
- [x] Characters outside cell
- [x] Center-point containment: char partially overlaps but center outside (excluded)
- [x] Center-point containment: char overflows but center inside (included)
- [x] Multiple words in cell (space-separated)
- [x] Multiple lines in cell (different y positions)
- [x] Two cells with different text
- [x] No cells (empty slice)
- [x] Mixed empty and populated cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)