### PR TITLE
feat: US-038 - Explicit strategy - user-provided lines/coordinates

### DIFF
--- a/crates/pdfplumber-core/src/edges.rs
+++ b/crates/pdfplumber-core/src/edges.rs
@@ -23,6 +23,8 @@ pub enum EdgeSource {
     Curve,
     /// Synthetic edge generated from text alignment patterns (Stream strategy).
     Stream,
+    /// User-provided explicit line coordinate (Explicit strategy).
+    Explicit,
 }
 
 /// A line segment edge for table detection.

--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -31,8 +31,8 @@ pub use path::{Path, PathBuilder, PathSegment};
 pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
 pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableSettings,
-    cells_to_tables, edges_to_intersections, extract_text_for_cells, intersections_to_cells,
-    join_edge_group, snap_edges, words_to_edges_stream,
+    cells_to_tables, edges_to_intersections, explicit_lines_to_edges, extract_text_for_cells,
+    intersections_to_cells, join_edge_group, snap_edges, words_to_edges_stream,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use words::{Word, WordExtractor, WordOptions};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -22,9 +22,9 @@ pub use pdfplumber_core::{
     StandardEncoding, Strategy, Table, TableFinder, TableSettings, TextBlock, TextDirection,
     TextLine, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text, cells_to_tables,
     cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, edge_from_curve,
-    edge_from_line, edges_from_rect, edges_to_intersections, extract_shapes,
-    extract_text_for_cells, image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text,
-    join_edge_group, snap_edges, sort_blocks_reading_order, split_lines_at_columns,
+    edge_from_line, edges_from_rect, edges_to_intersections, explicit_lines_to_edges,
+    extract_shapes, extract_text_for_cells, image_from_ctm, intersections_to_cells, is_cjk,
+    is_cjk_text, join_edge_group, snap_edges, sort_blocks_reading_order, split_lines_at_columns,
     words_to_edges_stream, words_to_text,
 };
 pub use pdfplumber_parse::{

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -183,7 +183,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 10,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -30,6 +30,8 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
 - `words_to_edges_stream(words, text_x_tol, text_y_tol, min_words_v, min_words_h)` generates synthetic edges from word alignment
 - Stream strategy: cluster words by x0/x1 (vertical edges) and top/bottom (horizontal edges), filter by min_words threshold
 - `TableFinder::new_with_words(edges, words, settings)` constructor for Stream strategy; `new()` still works with empty words
+- `explicit_lines_to_edges(explicit: &ExplicitLines) -> Vec<Edge>` converts coordinate lists to edges with `EdgeSource::Explicit`
+- Explicit strategy mixing: `find_tables()` computes bounding range from detected edges + explicit coordinates for edge span computation
 
 ---
 
@@ -156,4 +158,21 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - `TableFinder` now has a `words: Vec<Word>` field, empty by default for backward compatibility
   - Stream strategy uses text_x_tolerance/text_y_tolerance for clustering (not snap_tolerance)
   - 13 tests covering: empty words, x0/x1 vertical alignment, top/bottom horizontal alignment, threshold filtering, tolerance grouping, no grouping beyond tolerance, full pipeline, no words, edge source, min_words_horizontal default
+---
+
+## 2026-02-28 - US-038
+- Implemented Explicit strategy for user-provided line coordinates
+- Added `EdgeSource::Explicit` variant to edges.rs
+- Added `explicit_lines_to_edges()` standalone function that converts ExplicitLines (h/v coordinate lists) to Edge objects
+- Updated `TableFinder::find_tables()` with Explicit strategy handling including mixing support
+- Mixing: explicit edges are combined with detected edges, spans computed from both sources
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/edges.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - `explicit_lines_to_edges(explicit: &ExplicitLines) -> Vec<Edge>` is a standalone function for pure explicit grids
+  - Horizontal edges span from min(vertical_lines) to max(vertical_lines); verticals span from min(horizontal_lines) to max(horizontal_lines)
+  - Returns empty Vec if either list is empty (can't form a grid without both)
+  - Mixing in `find_tables()`: computes bounding range from both detected edges AND explicit coordinates, so explicit horizontal lines span the full x-range including detected edges
+  - All explicit edges have `EdgeSource::Explicit` for tracking provenance
+  - 13 tests covering: basic conversion, empty lists (h/v/both), edge source, grid detection (3x3/2x2), no explicit_lines, mixing with detected edges, single line each, unsorted coordinates
 ---


### PR DESCRIPTION
## Summary
- Added `EdgeSource::Explicit` variant for tracking provenance of user-provided edges
- Implemented `explicit_lines_to_edges()` function that converts `ExplicitLines` (horizontal/vertical coordinate lists) to `Edge` objects
- Updated `TableFinder::find_tables()` to handle the Explicit strategy with mixing support (combining explicit edges with detected edges)
- Horizontal edges span from min to max of vertical line x-coordinates; vertical edges span from min to max of horizontal line y-coordinates
- Mixing mode computes bounding range from both detected edges AND explicit coordinates

## Test plan
- [x] 13 unit tests covering: basic conversion, empty lists (h/v/both), edge source verification, grid detection (3x3/2x2), no explicit_lines, mixing with detected edges, single line each, unsorted coordinates
- [x] All existing tests pass (402 total)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)