### PR TITLE
feat: US-039 - Page table API - find_tables, extract_tables, extract_table

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -202,7 +202,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 11,
-      "passes": false,
+      "passes": true,
       "notes": "Capstone story for Phase 3."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -32,6 +32,9 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
 - `TableFinder::new_with_words(edges, words, settings)` constructor for Stream strategy; `new()` still works with empty words
 - `explicit_lines_to_edges(explicit: &ExplicitLines) -> Vec<Edge>` converts coordinate lists to edges with `EdgeSource::Explicit`
 - Explicit strategy mixing: `find_tables()` computes bounding range from detected edges + explicit coordinates for edge span computation
+- `Page::find_tables(settings)` → Vec<Table> with populated cell text; uses TableFinder internally
+- `Page::extract_tables(settings)` → Vec<Vec<Vec<Option<String>>>> (tables→rows→cells as text)
+- `Page::extract_table(settings)` → Option<Vec<Vec<Option<String>>>> (largest table by cell count)
 
 ---
 
@@ -175,4 +178,21 @@ Started: 2026년  2월 28일 토요일 09시 18분 01초 KST
   - Mixing in `find_tables()`: computes bounding range from both detected edges AND explicit coordinates, so explicit horizontal lines span the full x-range including detected edges
   - All explicit edges have `EdgeSource::Explicit` for tracking provenance
   - 13 tests covering: basic conversion, empty lists (h/v/both), edge source, grid detection (3x3/2x2), no explicit_lines, mixing with detected edges, single line each, unsorted coordinates
+---
+
+## 2026-02-28 - US-039
+- Implemented Page table API: `find_tables()`, `extract_tables()`, `extract_table()`
+- `find_tables(&self, settings: &TableSettings) -> Vec<Table>` creates a TableFinder with page edges + words, runs pipeline, populates cell text
+- `extract_tables(&self, settings: &TableSettings) -> Vec<Vec<Vec<Option<String>>>>` returns 2D text arrays
+- `extract_table(&self, settings: &TableSettings) -> Option<Vec<Vec<Option<String>>>>` returns largest table by cell count (then area)
+- Text extraction populates cells, rows, and columns separately via `extract_text_for_cells()`
+- Files changed: `crates/pdfplumber/src/page.rs`, `scripts/ralph/prd.json`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - Page methods import `TableFinder`, `TableSettings`, `Table`, `extract_text_for_cells` from pdfplumber-core
+  - `TableFinder::new_with_words()` is used for all strategies (words are empty Vec for non-Stream strategies, no harm)
+  - Text extraction must be called on `table.cells`, `table.rows[*]`, and `table.columns[*]` separately since they are independent copies
+  - `extract_table()` picks the largest table: first by cell count, then by bbox area as tiebreaker
+  - Test helpers `hline(x0, y, x1)` and `vline(x, top, bottom)` simplify line creation in tests
+  - 16 tests covering: simple bordered table, cell text, 2x2 table, empty page, no lines, rects only, extract_tables simple/2x2/empty/empty-cells, extract_table largest/none, stream strategy, explicit strategy, multiple tables, lattice strict
 ---


### PR DESCRIPTION
## Summary
- Adds `Page::find_tables(settings)` → `Vec<Table>` with populated cell text using `TableFinder` internally
- Adds `Page::extract_tables(settings)` → `Vec<Vec<Vec<Option<String>>>>` for tables as 2D text arrays
- Adds `Page::extract_table(settings)` → `Option<Vec<Vec<Option<String>>>>` returning the largest table
- Supports all strategies: Lattice, LatticeStrict, Stream (text-based), and Explicit (user-provided coordinates)
- Capstone story completing Phase 3: Table Detection

## Test plan
- [x] Unit test: simple bordered table detection (`test_find_tables_simple_bordered`)
- [x] Unit test: cell text extraction (`test_find_tables_cell_text`)
- [x] Unit test: 2x2 table (`test_find_tables_2x2`)
- [x] Unit test: empty page returns no tables (`test_find_tables_empty_page`)
- [x] Unit test: page with no lines returns no tables (`test_find_tables_no_lines`)
- [x] Unit test: table from rect edges (`test_find_tables_with_rects`)
- [x] Unit test: extract_tables API returns 2D arrays (`test_extract_tables_simple`, `test_extract_tables_2x2`)
- [x] Unit test: extract_tables empty page (`test_extract_tables_empty_page`)
- [x] Unit test: empty cell text (`test_extract_tables_empty_cells`)
- [x] Unit test: extract_table returns largest table (`test_extract_table_returns_largest`)
- [x] Unit test: extract_table returns None when empty (`test_extract_table_none_when_no_tables`)
- [x] Unit test: Stream strategy detection (`test_find_tables_stream_strategy`)
- [x] Unit test: Explicit strategy with text (`test_find_tables_explicit_strategy`)
- [x] Unit test: multiple tables extraction (`test_extract_tables_multiple_tables`)
- [x] Unit test: LatticeStrict excludes rect edges (`test_find_tables_lattice_strict`)
- [x] All quality checks pass: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)