### PR TITLE
feat: US-041 - CID fonts - Identity-H/V and subset font handling

### DIFF
--- a/crates/pdfplumber-parse/src/lib.rs
+++ b/crates/pdfplumber-parse/src/lib.rs
@@ -23,8 +23,8 @@ pub use backend::PdfBackend;
 pub use char_extraction::char_from_event;
 pub use cid_font::{
     CidFontMetrics, CidFontType, CidSystemInfo, CidToGidMap, PredefinedCMapInfo,
-    extract_cid_font_metrics, get_descendant_font, get_type0_encoding, is_type0_font,
-    parse_predefined_cmap_name, parse_w_array,
+    extract_cid_font_metrics, get_descendant_font, get_type0_encoding, is_subset_font,
+    is_type0_font, parse_predefined_cmap_name, parse_w_array, strip_subset_prefix,
 };
 pub use cmap::{CMap, CidCMap};
 pub use error::BackendError;
@@ -35,8 +35,8 @@ pub use lopdf_backend::{LopdfBackend, LopdfDocument, LopdfPage};
 pub use page_geometry::PageGeometry;
 pub use pdfplumber_core;
 pub use text_renderer::{
-    RawChar, TjElement, double_quote_show_string, quote_show_string, show_string,
-    show_string_with_positioning,
+    RawChar, TjElement, double_quote_show_string, quote_show_string, show_string, show_string_cid,
+    show_string_with_positioning, show_string_with_positioning_mode,
 };
 pub use text_state::{TextRenderMode, TextState};
 pub use tokenizer::{Operand, Operator, tokenize};

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -37,7 +37,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,6 +1,9 @@
 ## Codebase Patterns
 
 - **Font handling architecture**: Fonts are cached in `CachedFont` struct in interpreter.rs. Simple fonts use `FontMetrics` (widths array indexed by char_code - first_char). CID fonts use `CidFontMetrics` (HashMap<u32, f64> for sparse widths + default_width).
+- **CID font 2-byte char codes**: CID fonts use `show_string_cid()` which reads pairs of bytes as big-endian u16 character codes. Simple fonts use `show_string()` with single-byte codes. The `is_cid_font` flag on `CachedFont` controls dispatch.
+- **Subset font prefix**: PDF subset fonts use `ABCDEF+RealName` pattern. `strip_subset_prefix()` removes the 6-uppercase-letter prefix. Applied to all font `base_name` in the interpreter.
+- **TJ array CID mode**: `show_string_with_positioning_mode()` wraps `show_string_with_positioning` with a `cid_mode` flag to dispatch string elements to the CID 2-byte decoder.
 - **lopdf object resolution**: Always resolve indirect references via `resolve_object(doc, obj)` before accessing dictionaries or arrays.
 - **Width function pattern**: The interpreter creates a width closure `get_width_fn(cached)` that dispatches to CID or simple metrics.
 - **CMap types**: `CMap` maps char_code→Unicode string (for ToUnicode). `CidCMap` maps char_code→CID (for predefined CMaps).
@@ -23,4 +26,18 @@ Started: 2026년  2월 28일 토요일 10시 21분 21초 KST
   - Predefined CMap names follow patterns: Adobe-Japan1-*, UniJIS-UTF16-H, 90ms-RKSJ-H, etc.
   - clippy requires `#[allow(clippy::too_many_arguments)]` for constructors with 8+ params
   - Use `if let Ok(v) = x.parse()` not `if let Some(v) = x.parse().ok()` (clippy::match_result_ok)
+---
+
+## 2026-02-28 - US-041
+- Implemented Identity-H/V support, subset font handling, and 2-byte character codes for CID fonts
+- Modified: `crates/pdfplumber-parse/src/cid_font.rs` — Added `is_subset_font()` and `strip_subset_prefix()` functions with tests
+- Modified: `crates/pdfplumber-parse/src/text_renderer.rs` — Added `show_string_cid()` for 2-byte character code decoding and `show_string_with_positioning_mode()` for TJ arrays with CID mode
+- Modified: `crates/pdfplumber-parse/src/interpreter.rs` — Handle Tj/TJ dispatches to CID 2-byte mode for Type0 fonts; subset prefix stripping in font name extraction; integration tests for Identity-H, Identity-V, and subset font names
+- Modified: `crates/pdfplumber-parse/src/lib.rs` — Exports new functions
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - CID fonts use 2-byte character codes (big-endian u16), simple fonts use 1-byte codes
+  - Subset fonts follow strict pattern: exactly 6 uppercase letters + '+' + real name
+  - Identity-H and Identity-V map CID = character code directly; difference is writing mode (0=horizontal, 1=vertical)
+  - `is_some_and()` is a clean pattern for checking Option fields on borrowed references
 ---


### PR DESCRIPTION
## Summary
- Implement Identity-H and Identity-V CMap support for CID fonts (horizontal and vertical writing modes)
- Add subset font detection (`is_subset_font()`) and prefix stripping (`strip_subset_prefix()`) for font names like `ABCDEF+ArialMT`
- Add 2-byte character code handling (`show_string_cid()`) for CID/Type0 fonts in text operators (Tj, TJ)
- Integrate CID 2-byte mode into interpreter's text rendering pipeline

## Test plan
- [x] Unit tests: `is_subset_font()` with valid/invalid patterns
- [x] Unit tests: `strip_subset_prefix()` with/without prefix
- [x] Unit tests: Identity-H and Identity-V encoding detection
- [x] Unit tests: `show_string_cid()` 2-byte code parsing, empty input, odd byte length, position advancement
- [x] Integration tests: CID font with Identity-H produces 2-byte char codes
- [x] Integration tests: TJ array with CID font uses 2-byte mode
- [x] Integration tests: Subset font prefix stripped from font name
- [x] Integration tests: Identity-V encoding detected correctly
- [x] All quality checks pass: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)