### PR TITLE
feat: US-044 - rayon parallel page processing

### DIFF
--- a/crates/pdfplumber/Cargo.toml
+++ b/crates/pdfplumber/Cargo.toml
@@ -8,10 +8,12 @@ description = "Extract chars, words, lines, rects, and tables from PDF documents
 
 [features]
 serde = ["pdfplumber-core/serde"]
+parallel = ["dep:rayon"]
 
 [dependencies]
 pdfplumber-core = { path = "../pdfplumber-core" }
 pdfplumber-parse = { path = "../pdfplumber-parse" }
+rayon = { version = "1.10", optional = true }
 
 [dev-dependencies]
 lopdf = "0.34"

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -93,7 +93,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -10,6 +10,7 @@
 - **Type0 font loading flow**: `is_type0_font()` → `get_descendant_font()` → `extract_cid_font_metrics()` → stores in `CachedFont.cid_metrics`.
 - **Spatial filtering pattern**: `PageData` trait provides shared access to page data (chars, lines, rects, curves, images). Both `Page` and `CroppedPage` implement it. `filter_and_build()` takes `&dyn PageData` + `BBox` + `FilterMode` to produce a `CroppedPage`. Coordinates adjusted by subtracting crop origin.
 - **Serde feature flag pattern**: Use `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]` on all public data types. Feature in pdfplumber-core, forwarded from pdfplumber via `pdfplumber-core/serde`. serde_json as dev-dependency for tests.
+- **Parallel feature pattern**: `parallel = ["dep:rayon"]` in pdfplumber Cargo.toml. Methods gated with `#[cfg(feature = "parallel")]`. `Pdf` is naturally `Sync` (lopdf::Document is Send+Sync), so `&Pdf` can be shared across rayon threads. Test helpers for parallel-only code also need `#[cfg(feature = "parallel")]`.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 10시 21분 21초 KST
@@ -69,4 +70,17 @@ Started: 2026년  2월 28일 토요일 10시 21분 21초 KST
   - serde_json dev-dependency is sufficient for testing; no runtime serde_json dependency needed
   - All types including nested ones (PathSegment→Point, Color→Vec<f32>) must have derives for parent derives to work
   - Feature forwarding: pdfplumber's `serde` feature enables `pdfplumber-core/serde` via Cargo dependency feature syntax
+---
+
+## 2026-02-28 - US-044
+- Added optional rayon-based parallel page processing behind `parallel` feature flag
+- Modified: `crates/pdfplumber/Cargo.toml` — Added `parallel` feature flag, rayon 1.10 as optional dep
+- Modified: `crates/pdfplumber/src/pdf.rs` — Added `Pdf::pages_parallel()` method (behind `#[cfg(feature = "parallel")]`), 5 parallel tests (returns all pages, matches sequential, single page, doctop preservation, Sync compile check), multi-page PDF test helper
+- Dependencies added: rayon 1.10 (optional, behind `parallel` feature)
+- **Learnings for future iterations:**
+  - `lopdf::Document` is `Send + Sync`, so `Pdf` is naturally `Sync` — no wrapper needed for `&Pdf` sharing across threads
+  - rayon's `into_par_iter().map().collect()` is a clean 1:1 replacement for sequential iteration
+  - `Pdf::page()` takes `&self` and all internal state (`doc`, `page_heights`, `raw_page_heights`, `options`) is read-only — inherently thread-safe
+  - Test helpers used only with a feature must be gated with `#[cfg(feature = "...")]` to avoid dead_code warnings
+  - `dep:rayon` syntax (not `rayon = ["rayon"]`) is the modern Cargo way to declare optional features
 ---


### PR DESCRIPTION
## Summary
- Added optional rayon-based parallel page processing behind a `parallel` feature flag
- `Pdf::pages_parallel()` processes all pages concurrently using rayon's `par_iter`, returning `Vec<Result<Page, PdfError>>`
- rayon 1.10 added as optional dependency (only included when `parallel` feature is enabled)
- Non-parallel code paths are completely unchanged when the feature is disabled

## Key changes
- `crates/pdfplumber/Cargo.toml` — Added `parallel = ["dep:rayon"]` feature flag and rayon optional dependency
- `crates/pdfplumber/src/pdf.rs` — Added `Pdf::pages_parallel()` method gated behind `#[cfg(feature = "parallel")]`, 5 unit tests, multi-page PDF test helper

## Test plan
- [x] `cargo test --workspace` passes (all 92+ pdfplumber tests)
- [x] `cargo test --workspace --features parallel` passes (97 tests including 5 new parallel tests)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo clippy --workspace --features parallel -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Parallel extraction matches sequential extraction (char content, positions, doctop offsets)
- [x] Compile-time Sync assertion for Pdf type

🤖 Generated with [Claude Code](https://claude.com/claude-code)