### PR TITLE
feat: US-047 - WASM build support

### DIFF
--- a/crates/pdfplumber-parse/Cargo.toml
+++ b/crates/pdfplumber-parse/Cargo.toml
@@ -8,5 +8,5 @@ description = "PDF parsing and content stream interpreter for pdfplumber-rs"
 
 [dependencies]
 pdfplumber-core = { path = "../pdfplumber-core" }
-lopdf = "0.34"
+lopdf = { version = "0.34", default-features = false, features = ["nom_parser"] }
 thiserror = "2"

--- a/crates/pdfplumber/Cargo.toml
+++ b/crates/pdfplumber/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 description = "Extract chars, words, lines, rects, and tables from PDF documents with precise coordinates"
 
 [features]
+default = ["std"]
+std = []
 serde = ["pdfplumber-core/serde"]
 parallel = ["dep:rayon"]
 

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -8,6 +8,34 @@
 //! - **pdfplumber-core**: Backend-independent data types and algorithms
 //! - **pdfplumber-parse**: PDF parsing (Layer 1) and content stream interpreter (Layer 2)
 //! - **pdfplumber** (this crate): Public API that ties everything together
+//!
+//! # Feature Flags
+//!
+//! | Feature | Default | Description |
+//! |---------|---------|-------------|
+//! | `std` | Yes | Enables file-path APIs (`Pdf::open_file`). Disable for WASM. |
+//! | `serde` | No | Adds Serialize/Deserialize to all public data types. |
+//! | `parallel` | No | Enables `Pdf::pages_parallel()` via rayon. Not WASM-compatible. |
+//!
+//! # WASM Support
+//!
+//! This crate compiles for `wasm32-unknown-unknown`. For WASM builds, disable
+//! the default `std` feature and use the bytes-based API:
+//!
+//! ```toml
+//! [dependencies]
+//! pdfplumber = { version = "0.1", default-features = false }
+//! ```
+//!
+//! Then use [`Pdf::open`] with a byte slice:
+//!
+//! ```ignore
+//! let pdf = Pdf::open(pdf_bytes, None)?;
+//! let page = pdf.page(0)?;
+//! let text = page.extract_text(&TextOptions::default());
+//! ```
+//!
+//! The `parallel` feature is not available for WASM targets (rayon requires OS threads).
 
 mod cropped_page;
 mod page;

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -146,7 +146,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 8,
-      "passes": false,
+      "passes": true,
       "notes": "May need to gate certain features behind cfg."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -13,6 +13,7 @@
 - **Serde feature flag pattern**: Use `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]` on all public data types. Feature in pdfplumber-core, forwarded from pdfplumber via `pdfplumber-core/serde`. serde_json as dev-dependency for tests.
 - **Parallel feature pattern**: `parallel = ["dep:rayon"]` in pdfplumber Cargo.toml. Methods gated with `#[cfg(feature = "parallel")]`. `Pdf` is naturally `Sync` (lopdf::Document is Send+Sync), so `&Pdf` can be shared across rayon threads. Test helpers for parallel-only code also need `#[cfg(feature = "parallel")]`.
 - **Warning collection pattern**: `ExtractWarning` has `description`, `page`, `element`, `operator_index`, `font_name` fields. Interpreter emits warnings via `handler.on_warning()` gated by `options.collect_warnings`. The handler decorates warnings with page context. Page exposes `warnings()` accessor. Warnings are purely informational and never affect extraction output.
+- **WASM/std feature pattern**: `std` feature (default) gates `Pdf::open_file()` behind `#[cfg(feature = "std")]`. Bytes-based `Pdf::open()` works everywhere. lopdf uses `default-features = false, features = ["nom_parser"]` to minimize deps. All three crates compile for `wasm32-unknown-unknown`.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 10시 21분 21초 KST
@@ -116,4 +117,19 @@ Started: 2026년  2월 28일 토요일 10시 21분 21초 KST
   - `Page` data is fully owned (Vec<Char>, Vec<Image>, etc.) — no shared references back to `Pdf`
   - `ExactSizeIterator` can be derived trivially since page_count is known upfront
   - Partial iteration (consuming only some pages) works cleanly — iterator drop is a no-op
+---
+
+## 2026-02-28 - US-047
+- Implemented WASM build support: all three crates compile for wasm32-unknown-unknown
+- Modified: `crates/pdfplumber-parse/Cargo.toml` — lopdf with `default-features = false, features = ["nom_parser"]` to exclude chrono/rayon from dependency tree
+- Modified: `crates/pdfplumber/Cargo.toml` — Added `std` feature (default), `default = ["std"]`
+- Modified: `crates/pdfplumber/src/pdf.rs` — Added `Pdf::open_file()` behind `#[cfg(feature = "std")]`; 3 std-gated tests (open_file_reads_valid_pdf, open_file_nonexistent_returns_error, open_file_matches_open_bytes) + 1 bytes API test
+- Modified: `crates/pdfplumber/src/lib.rs` — Added WASM usage documentation and feature flags table to crate-level docs
+- Modified: `scripts/ralph/prd.json` — Set US-047 passes: true
+- Dependencies added: none (lopdf features trimmed)
+- **Learnings for future iterations:**
+  - lopdf 0.34 compiles for wasm32-unknown-unknown even with chrono (chrono uses `js-sys` for WASM). But disabling defaults reduces binary size.
+  - The codebase had no `std::fs`, `std::time::Instant`, or other WASM-incompatible APIs — pure bytes-based design from the start
+  - lopdf's `nom_parser` feature is the minimal set needed; `chrono_time` and `rayon` defaults are unnecessary
+  - `PdfError::IoError(String)` already existed, perfect for wrapping `std::fs::read` errors
 ---


### PR DESCRIPTION
## Summary
- Add `std` feature flag (default) gating `Pdf::open_file()` for file-path API
- Disable unnecessary lopdf defaults (`chrono_time`, `rayon`) via `default-features = false, features = ["nom_parser"]`
- All three crates (`pdfplumber-core`, `pdfplumber-parse`, `pdfplumber`) compile for `wasm32-unknown-unknown` target
- Bytes-based `Pdf::open()` works in all environments including WASM
- Document WASM usage and feature flags in crate-level docs

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown -p pdfplumber-core` passes
- [x] `cargo check --target wasm32-unknown-unknown -p pdfplumber` passes (with and without default features)
- [x] `open_file_reads_valid_pdf` - writes PDF to temp file, opens via `Pdf::open_file`, verifies content
- [x] `open_file_nonexistent_returns_error` - verifies error for missing file
- [x] `open_file_matches_open_bytes` - verifies `open_file` produces same results as `open`
- [x] `bytes_api_works_without_filesystem` - verifies bytes-based API works standalone
- [x] All 421 existing tests pass
- [x] `cargo fmt`, `cargo clippy`, `cargo check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)