### PR TITLE
feat: US-050 - CLI crate scaffolding with clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/pdfplumber-core",
     "crates/pdfplumber-parse",
     "crates/pdfplumber",
+    "crates/pdfplumber-cli",
 ]
 resolver = "3"
 

--- a/crates/pdfplumber-cli/Cargo.toml
+++ b/crates/pdfplumber-cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pdfplumber-cli"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Command-line tool to extract text, characters, words, and tables from PDF documents"
+keywords = ["pdf", "cli", "table", "text-extraction"]
+categories = ["command-line-utilities"]
+
+[[bin]]
+name = "pdfplumber"
+path = "src/main.rs"
+
+[dependencies]
+pdfplumber = { version = "0.1.0", path = "../pdfplumber" }
+clap = { version = "4", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/crates/pdfplumber-cli/src/cli.rs
+++ b/crates/pdfplumber-cli/src/cli.rs
@@ -1,0 +1,245 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+/// Extract text, characters, words, and tables from PDF documents.
+#[derive(Debug, Parser)]
+#[command(name = "pdfplumber", about, version)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Available subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Extract text from PDF pages
+    Text {
+        /// Path to the PDF file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Page range (e.g. '1,3-5'). Default: all pages
+        #[arg(long)]
+        pages: Option<String>,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = TextFormat::Text)]
+        format: TextFormat,
+
+        /// Use layout-preserving text extraction
+        #[arg(long)]
+        layout: bool,
+    },
+
+    /// Extract individual characters with coordinates
+    Chars {
+        /// Path to the PDF file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Page range (e.g. '1,3-5'). Default: all pages
+        #[arg(long)]
+        pages: Option<String>,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
+    },
+
+    /// Extract words with bounding box coordinates
+    Words {
+        /// Path to the PDF file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Page range (e.g. '1,3-5'). Default: all pages
+        #[arg(long)]
+        pages: Option<String>,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
+    },
+
+    /// Detect and extract tables from PDF pages
+    Tables {
+        /// Path to the PDF file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Page range (e.g. '1,3-5'). Default: all pages
+        #[arg(long)]
+        pages: Option<String>,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
+    },
+}
+
+/// Output format for text subcommand.
+#[derive(Debug, Clone, ValueEnum)]
+pub enum TextFormat {
+    /// Plain text output
+    Text,
+    /// JSON output
+    Json,
+}
+
+/// Output format for chars/words/tables subcommands.
+#[derive(Debug, Clone, ValueEnum)]
+pub enum OutputFormat {
+    /// Plain text (tab-separated)
+    Text,
+    /// JSON output
+    Json,
+    /// CSV output
+    Csv,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parse_text_subcommand_with_file() {
+        let cli = Cli::parse_from(["pdfplumber", "text", "test.pdf"]);
+        match cli.command {
+            Commands::Text { ref file, .. } => {
+                assert_eq!(file, &PathBuf::from("test.pdf"));
+            }
+            _ => panic!("expected Text subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_text_with_pages_and_format() {
+        let cli = Cli::parse_from([
+            "pdfplumber",
+            "text",
+            "test.pdf",
+            "--pages",
+            "1,3-5",
+            "--format",
+            "json",
+        ]);
+        match cli.command {
+            Commands::Text {
+                ref file,
+                ref pages,
+                ref format,
+                layout,
+            } => {
+                assert_eq!(file, &PathBuf::from("test.pdf"));
+                assert_eq!(pages.as_deref(), Some("1,3-5"));
+                assert!(matches!(format, TextFormat::Json));
+                assert!(!layout);
+            }
+            _ => panic!("expected Text subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_text_with_layout_flag() {
+        let cli = Cli::parse_from(["pdfplumber", "text", "test.pdf", "--layout"]);
+        match cli.command {
+            Commands::Text { layout, .. } => {
+                assert!(layout);
+            }
+            _ => panic!("expected Text subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_chars_subcommand() {
+        let cli = Cli::parse_from(["pdfplumber", "chars", "input.pdf"]);
+        match cli.command {
+            Commands::Chars { ref file, .. } => {
+                assert_eq!(file, &PathBuf::from("input.pdf"));
+            }
+            _ => panic!("expected Chars subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_chars_with_csv_format() {
+        let cli = Cli::parse_from(["pdfplumber", "chars", "input.pdf", "--format", "csv"]);
+        match cli.command {
+            Commands::Chars { ref format, .. } => {
+                assert!(matches!(format, OutputFormat::Csv));
+            }
+            _ => panic!("expected Chars subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_words_subcommand() {
+        let cli = Cli::parse_from(["pdfplumber", "words", "test.pdf"]);
+        match cli.command {
+            Commands::Words { ref file, .. } => {
+                assert_eq!(file, &PathBuf::from("test.pdf"));
+            }
+            _ => panic!("expected Words subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_tables_subcommand() {
+        let cli = Cli::parse_from(["pdfplumber", "tables", "test.pdf"]);
+        match cli.command {
+            Commands::Tables { ref file, .. } => {
+                assert_eq!(file, &PathBuf::from("test.pdf"));
+            }
+            _ => panic!("expected Tables subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_tables_with_all_options() {
+        let cli = Cli::parse_from([
+            "pdfplumber",
+            "tables",
+            "doc.pdf",
+            "--pages",
+            "2-4",
+            "--format",
+            "json",
+        ]);
+        match cli.command {
+            Commands::Tables {
+                ref file,
+                ref pages,
+                ref format,
+            } => {
+                assert_eq!(file, &PathBuf::from("doc.pdf"));
+                assert_eq!(pages.as_deref(), Some("2-4"));
+                assert!(matches!(format, OutputFormat::Json));
+            }
+            _ => panic!("expected Tables subcommand"),
+        }
+    }
+
+    #[test]
+    fn text_default_format_is_text() {
+        let cli = Cli::parse_from(["pdfplumber", "text", "test.pdf"]);
+        match cli.command {
+            Commands::Text { ref format, .. } => {
+                assert!(matches!(format, TextFormat::Text));
+            }
+            _ => panic!("expected Text subcommand"),
+        }
+    }
+
+    #[test]
+    fn chars_default_format_is_text() {
+        let cli = Cli::parse_from(["pdfplumber", "chars", "test.pdf"]);
+        match cli.command {
+            Commands::Chars { ref format, .. } => {
+                assert!(matches!(format, OutputFormat::Text));
+            }
+            _ => panic!("expected Chars subcommand"),
+        }
+    }
+}

--- a/crates/pdfplumber-cli/src/main.rs
+++ b/crates/pdfplumber-cli/src/main.rs
@@ -1,0 +1,27 @@
+mod cli;
+
+use clap::Parser;
+use cli::Cli;
+
+fn main() {
+    let _cli = Cli::parse();
+
+    match _cli.command {
+        cli::Commands::Text { .. } => {
+            eprintln!("text subcommand not yet implemented");
+            std::process::exit(1);
+        }
+        cli::Commands::Chars { .. } => {
+            eprintln!("chars subcommand not yet implemented");
+            std::process::exit(1);
+        }
+        cli::Commands::Words { .. } => {
+            eprintln!("words subcommand not yet implemented");
+            std::process::exit(1);
+        }
+        cli::Commands::Tables { .. } => {
+            eprintln!("tables subcommand not yet implemented");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/pdfplumber-cli/tests/cli_args.rs
+++ b/crates/pdfplumber-cli/tests/cli_args.rs
@@ -1,0 +1,80 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn cmd() -> Command {
+    Command::cargo_bin("pdfplumber").unwrap()
+}
+
+#[test]
+fn help_flag_prints_usage_with_subcommands() {
+    cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("text"))
+        .stdout(predicate::str::contains("chars"))
+        .stdout(predicate::str::contains("words"))
+        .stdout(predicate::str::contains("tables"));
+}
+
+#[test]
+fn text_subcommand_help() {
+    cmd()
+        .args(["text", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FILE"))
+        .stdout(predicate::str::contains("--pages"))
+        .stdout(predicate::str::contains("--format"));
+}
+
+#[test]
+fn chars_subcommand_help() {
+    cmd()
+        .args(["chars", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FILE"))
+        .stdout(predicate::str::contains("--pages"))
+        .stdout(predicate::str::contains("--format"));
+}
+
+#[test]
+fn words_subcommand_help() {
+    cmd()
+        .args(["words", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FILE"))
+        .stdout(predicate::str::contains("--pages"))
+        .stdout(predicate::str::contains("--format"));
+}
+
+#[test]
+fn tables_subcommand_help() {
+    cmd()
+        .args(["tables", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FILE"))
+        .stdout(predicate::str::contains("--pages"))
+        .stdout(predicate::str::contains("--format"));
+}
+
+#[test]
+fn no_args_shows_help() {
+    // Running with no subcommand should show usage / error
+    cmd()
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage"));
+}
+
+#[test]
+fn text_requires_file_argument() {
+    cmd()
+        .arg("text")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("FILE"));
+}

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -20,7 +20,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "clap is a new dependency - justified as the standard Rust CLI framework."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,24 +1,31 @@
 ## Codebase Patterns
-
-- **Font handling architecture**: Fonts are cached in `CachedFont` struct in interpreter.rs. Simple fonts use `FontMetrics` (widths array indexed by char_code - first_char). CID fonts use `CidFontMetrics` (HashMap<u32, f64> for sparse widths + default_width).
-- **CID font 2-byte char codes**: CID fonts use `show_string_cid()` which reads pairs of bytes as big-endian u16 character codes. Simple fonts use `show_string()` with single-byte codes. The `is_cid_font` flag on `CachedFont` controls dispatch.
-- **Subset font prefix**: PDF subset fonts use `ABCDEF+RealName` pattern. `strip_subset_prefix()` removes the 6-uppercase-letter prefix. Applied to all font `base_name` in the interpreter.
-- **TJ array CID mode**: `show_string_with_positioning_mode()` wraps `show_string_with_positioning` with a `cid_mode` flag to dispatch string elements to the CID 2-byte decoder.
-- **lopdf object resolution**: Always resolve indirect references via `resolve_object(doc, obj)` before accessing dictionaries or arrays.
-- **Width function pattern**: The interpreter creates a width closure `get_width_fn(cached)` that dispatches to CID or simple metrics.
-- **CMap types**: `CMap` maps char_code→Unicode string (for ToUnicode). `CidCMap` maps char_code→CID (for predefined CMaps).
-- **Type0 font loading flow**: `is_type0_font()` → `get_descendant_font()` → `extract_cid_font_metrics()` → stores in `CachedFont.cid_metrics`.
-- **Spatial filtering pattern**: `PageData` trait provides shared access to page data (chars, lines, rects, curves, images). Both `Page` and `CroppedPage` implement it. `filter_and_build()` takes `&dyn PageData` + `BBox` + `FilterMode` to produce a `CroppedPage`. Coordinates adjusted by subtracting crop origin.
-- **Page-level memory pattern**: `Pdf::page(index)` processes pages on-demand (interprets content stream per call). Page data is fully owned by `Page` (released on drop). `Pdf::pages_iter()` returns `PagesIter` (borrows `&Pdf`) that yields `Result<Page, PdfError>` — implements `ExactSizeIterator`. No shared state between pages; each page call is independent.
-- **Serde feature flag pattern**: Use `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]` on all public data types. Feature in pdfplumber-core, forwarded from pdfplumber via `pdfplumber-core/serde`. serde_json as dev-dependency for tests.
-- **Parallel feature pattern**: `parallel = ["dep:rayon"]` in pdfplumber Cargo.toml. Methods gated with `#[cfg(feature = "parallel")]`. `Pdf` is naturally `Sync` (lopdf::Document is Send+Sync), so `&Pdf` can be shared across rayon threads. Test helpers for parallel-only code also need `#[cfg(feature = "parallel")]`.
-- **Warning collection pattern**: `ExtractWarning` has `description`, `page`, `element`, `operator_index`, `font_name` fields. Interpreter emits warnings via `handler.on_warning()` gated by `options.collect_warnings`. The handler decorates warnings with page context. Page exposes `warnings()` accessor. Warnings are purely informational and never affect extraction output.
-- **WASM/std feature pattern**: `std` feature (default) gates `Pdf::open_file()` behind `#[cfg(feature = "std")]`. Bytes-based `Pdf::open()` works everywhere. lopdf uses `default-features = false, features = ["nom_parser"]` to minimize deps. All three crates compile for `wasm32-unknown-unknown`.
+- Workspace root Cargo.toml has `members` array for all crates
+- Each crate uses `edition.workspace = true`, `rust-version.workspace = true`, `license.workspace = true`, `repository.workspace = true`
+- Facade crate (`pdfplumber`) re-exports from `pdfplumber-core` and `pdfplumber-parse`
+- Page API: `Pdf::open_file(path, None)`, `pdf.page(idx)`, `pdf.pages_iter()`, `pdf.page_count()`
+- Page methods: `page.chars()`, `page.extract_words(opts)`, `page.extract_text(opts)`, `page.find_tables(settings)`
+- Char fields: text, fontname, size, x0, top, x1, bottom, doctop, upright, direction
+- Word fields: text, x0, top, x1, bottom, doctop, direction
+- Table has `rows: Vec<Vec<Cell>>`, Cell has `text: Option<String>`
+- Integration tests in `crates/pdfplumber/tests/` use real PDFs from `tests/fixtures/`
+- CLI crate uses `assert_cmd` and `predicates` for integration tests
 
 # Ralph Progress Log
-Started: 2026년  2월 28일 토요일 10시 21분 21초 KST
+Started: 2026년  2월 28일 토요일 14시 03분 29초 KST
 ---
 
-# Ralph Progress Log - Phase 5: CLI - Command-line interface for pdfplumber-rs
-Started: 2026년  2월 28일 토요일 14시 03분 28초 KST
+## 2026-02-28 - US-050
+- Implemented CLI crate scaffolding with clap-based argument parsing
+- Created `crates/pdfplumber-cli` with `[[bin]] name = "pdfplumber"`
+- Added to workspace members in root Cargo.toml
+- Defined CLI struct with 4 subcommands: Text, Chars, Words, Tables
+- All subcommands accept positional FILE arg, --pages, --format options
+- Text subcommand has extra --layout flag; TextFormat (text/json) vs OutputFormat (text/json/csv)
+- 10 unit tests (clap parsing) + 7 integration tests (assert_cmd --help and error cases)
+- Files changed: Cargo.toml, crates/pdfplumber-cli/{Cargo.toml, src/main.rs, src/cli.rs, tests/cli_args.rs}
+- Dependencies added: clap (with derive), assert_cmd (dev), predicates (dev)
+- **Learnings for future iterations:**
+  - `assert_cmd::Command::cargo_bin` is deprecated in favor of `cargo::cargo_bin_cmd!` macro but still works
+  - clap derive requires `#[command(subcommand)]` on the enum field and `#[derive(Subcommand)]` on the enum
+  - Subcommand stubs use `eprintln!` + `std::process::exit(1)` for not-yet-implemented commands
 ---


### PR DESCRIPTION
## Summary

- Created new `pdfplumber-cli` crate in the workspace with `[[bin]] name = "pdfplumber"`
- Added clap-based argument parsing with derive macros
- Defined 4 subcommands: `text`, `chars`, `words`, `tables`
- All subcommands accept positional `<FILE>` argument and `--pages`/`--format` options
- Text subcommand includes `--layout` flag; text format (text/json) vs output format (text/json/csv)

## Test plan

- [x] 10 unit tests for clap argument parsing (all subcommands, options, defaults)
- [x] 7 integration tests using assert_cmd (--help outputs, error cases)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)