### PR TITLE
feat: US-051 - CLI 'text' subcommand - extract text from PDF

### DIFF
--- a/crates/pdfplumber-cli/Cargo.toml
+++ b/crates/pdfplumber-cli/Cargo.toml
@@ -21,3 +21,5 @@ serde_json = "1.0"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+lopdf = "0.36"
+tempfile = "3"

--- a/crates/pdfplumber-cli/src/main.rs
+++ b/crates/pdfplumber-cli/src/main.rs
@@ -1,27 +1,35 @@
 mod cli;
+mod page_range;
+mod text_cmd;
 
 use clap::Parser;
 use cli::Cli;
 
 fn main() {
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
 
-    match _cli.command {
-        cli::Commands::Text { .. } => {
-            eprintln!("text subcommand not yet implemented");
-            std::process::exit(1);
-        }
+    let result = match cli.command {
+        cli::Commands::Text {
+            ref file,
+            ref pages,
+            ref format,
+            layout,
+        } => text_cmd::run(file, pages.as_deref(), format, layout),
         cli::Commands::Chars { .. } => {
             eprintln!("chars subcommand not yet implemented");
-            std::process::exit(1);
+            Err(1)
         }
         cli::Commands::Words { .. } => {
             eprintln!("words subcommand not yet implemented");
-            std::process::exit(1);
+            Err(1)
         }
         cli::Commands::Tables { .. } => {
             eprintln!("tables subcommand not yet implemented");
-            std::process::exit(1);
+            Err(1)
         }
+    };
+
+    if let Err(code) = result {
+        std::process::exit(code);
     }
 }

--- a/crates/pdfplumber-cli/src/page_range.rs
+++ b/crates/pdfplumber-cli/src/page_range.rs
@@ -1,0 +1,116 @@
+/// Parse a page range string like "1,3-5" into a sorted list of 0-indexed page numbers.
+///
+/// Input is 1-indexed (user-facing). Output is 0-indexed (internal).
+/// Returns an error for invalid input (page 0, malformed ranges, etc.).
+pub fn parse_page_range(input: &str, page_count: usize) -> Result<Vec<usize>, String> {
+    let mut pages = Vec::new();
+
+    for part in input.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+
+        if let Some((start_str, end_str)) = part.split_once('-') {
+            let start: usize = start_str
+                .trim()
+                .parse()
+                .map_err(|_| format!("invalid page number: '{start_str}'"))?;
+            let end: usize = end_str
+                .trim()
+                .parse()
+                .map_err(|_| format!("invalid page number: '{end_str}'"))?;
+
+            if start == 0 || end == 0 {
+                return Err("page 0 is invalid (pages start at 1)".to_string());
+            }
+            if start > page_count {
+                return Err(format!(
+                    "page {start} exceeds document page count ({page_count})"
+                ));
+            }
+            if end > page_count {
+                return Err(format!(
+                    "page {end} exceeds document page count ({page_count})"
+                ));
+            }
+
+            for p in start..=end {
+                pages.push(p - 1); // convert to 0-indexed
+            }
+        } else {
+            let page: usize = part
+                .parse()
+                .map_err(|_| format!("invalid page number: '{part}'"))?;
+
+            if page == 0 {
+                return Err("page 0 is invalid (pages start at 1)".to_string());
+            }
+            if page > page_count {
+                return Err(format!(
+                    "page {page} exceeds document page count ({page_count})"
+                ));
+            }
+
+            pages.push(page - 1);
+        }
+    }
+
+    pages.sort();
+    pages.dedup();
+    Ok(pages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_page() {
+        assert_eq!(parse_page_range("1", 5).unwrap(), vec![0]);
+        assert_eq!(parse_page_range("3", 5).unwrap(), vec![2]);
+    }
+
+    #[test]
+    fn page_range() {
+        assert_eq!(parse_page_range("2-4", 5).unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn comma_separated() {
+        assert_eq!(parse_page_range("1,3,5", 5).unwrap(), vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn mixed() {
+        assert_eq!(
+            parse_page_range("1-3,7,10-12", 12).unwrap(),
+            vec![0, 1, 2, 6, 9, 10, 11]
+        );
+    }
+
+    #[test]
+    fn page_zero_invalid() {
+        let err = parse_page_range("0", 5).unwrap_err();
+        assert!(err.contains("invalid"));
+    }
+
+    #[test]
+    fn page_exceeds_count() {
+        let err = parse_page_range("6", 5).unwrap_err();
+        assert!(err.contains("exceeds"));
+    }
+
+    #[test]
+    fn duplicates_removed() {
+        assert_eq!(parse_page_range("1,1,2", 5).unwrap(), vec![0, 1]);
+    }
+
+    #[test]
+    fn whitespace_tolerance() {
+        assert_eq!(
+            parse_page_range(" 1 , 3 - 5 ", 5).unwrap(),
+            vec![0, 2, 3, 4]
+        );
+    }
+}

--- a/crates/pdfplumber-cli/src/text_cmd.rs
+++ b/crates/pdfplumber-cli/src/text_cmd.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+
+use pdfplumber::{Pdf, TextOptions};
+
+use crate::cli::TextFormat;
+use crate::page_range::parse_page_range;
+
+pub fn run(file: &Path, pages: Option<&str>, format: &TextFormat, layout: bool) -> Result<(), i32> {
+    // Open PDF with user-friendly error messages
+    let pdf = open_pdf(file)?;
+
+    // Resolve page indices
+    let page_indices = resolve_pages(pages, pdf.page_count())?;
+
+    let text_options = TextOptions {
+        layout,
+        ..TextOptions::default()
+    };
+
+    for &idx in &page_indices {
+        let page = pdf.page(idx).map_err(|e| {
+            eprintln!("Error reading page {}: {e}", idx + 1);
+            1
+        })?;
+
+        let text = page.extract_text(&text_options);
+
+        match format {
+            TextFormat::Text => {
+                println!("--- Page {} ---", idx + 1);
+                println!("{text}");
+            }
+            TextFormat::Json => {
+                let obj = serde_json::json!({
+                    "page": idx + 1,
+                    "text": text,
+                });
+                println!("{}", serde_json::to_string(&obj).unwrap());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn open_pdf(file: &Path) -> Result<Pdf, i32> {
+    if !file.exists() {
+        eprintln!("Error: file not found: {}", file.display());
+        return Err(1);
+    }
+
+    Pdf::open_file(file, None).map_err(|e| {
+        eprintln!("Error: failed to open PDF: {e}");
+        1
+    })
+}
+
+fn resolve_pages(pages: Option<&str>, page_count: usize) -> Result<Vec<usize>, i32> {
+    match pages {
+        Some(range) => parse_page_range(range, page_count).map_err(|e| {
+            eprintln!("Error: {e}");
+            1
+        }),
+        None => Ok((0..page_count).collect()),
+    }
+}

--- a/crates/pdfplumber-cli/tests/text_cmd.rs
+++ b/crates/pdfplumber-cli/tests/text_cmd.rs
@@ -1,0 +1,325 @@
+//! Integration tests for the `text` subcommand (US-051).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+
+fn cmd() -> Command {
+    Command::cargo_bin("pdfplumber").unwrap()
+}
+
+/// Create a single-page PDF with the given content stream using lopdf.
+fn pdf_with_content(content: &[u8]) -> Vec<u8> {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+
+    let stream = Stream::new(dictionary! {}, content.to_vec());
+    let content_id = doc.add_object(stream);
+
+    let resources = dictionary! {
+        "Font" => dictionary! {
+            "F1" => Object::Reference(font_id),
+        },
+    };
+
+    let media_box = vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ];
+    let page_dict = dictionary! {
+        "Type" => "Page",
+        "MediaBox" => media_box,
+        "Contents" => Object::Reference(content_id),
+        "Resources" => resources,
+    };
+    let page_id = doc.add_object(page_dict);
+
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => vec![Object::Reference(page_id)],
+        "Count" => Object::Integer(1),
+    };
+    let pages_id = doc.add_object(pages_dict);
+
+    if let Ok(page_obj) = doc.get_object_mut(page_id) {
+        if let Ok(dict) = page_obj.as_dict_mut() {
+            dict.set("Parent", Object::Reference(pages_id));
+        }
+    }
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).unwrap();
+    buf
+}
+
+/// Create a multi-page PDF. Each page has a single line of text.
+fn pdf_with_pages(texts: &[&str]) -> Vec<u8> {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+
+    let media_box = vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ];
+
+    let mut page_ids = Vec::new();
+    for text in texts {
+        let content_str = format!("BT /F1 12 Tf 72 720 Td ({text}) Tj ET");
+        let stream = Stream::new(dictionary! {}, content_str.into_bytes());
+        let content_id = doc.add_object(stream);
+
+        let resources = dictionary! {
+            "Font" => dictionary! { "F1" => Object::Reference(font_id) },
+        };
+
+        let page_dict = dictionary! {
+            "Type" => "Page",
+            "MediaBox" => media_box.clone(),
+            "Contents" => Object::Reference(content_id),
+            "Resources" => resources,
+        };
+        page_ids.push(doc.add_object(page_dict));
+    }
+
+    let kids: Vec<Object> = page_ids.iter().map(|id| Object::Reference(*id)).collect();
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => kids,
+        "Count" => Object::Integer(texts.len() as i64),
+    };
+    let pages_id = doc.add_object(pages_dict);
+
+    for &pid in &page_ids {
+        if let Ok(page_obj) = doc.get_object_mut(pid) {
+            if let Ok(dict) = page_obj.as_dict_mut() {
+                dict.set("Parent", Object::Reference(pages_id));
+            }
+        }
+    }
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).unwrap();
+    buf
+}
+
+/// Write PDF bytes to a temporary file and return the path.
+fn write_temp_pdf(bytes: &[u8]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new().suffix(".pdf").tempfile().unwrap();
+    f.write_all(bytes).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+// --- Text output tests ---
+
+#[test]
+fn text_extracts_from_single_page() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello World) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["text", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Hello World"));
+}
+
+#[test]
+fn text_shows_page_separators_for_multi_page() {
+    let pdf_bytes = pdf_with_pages(&["Page One", "Page Two", "Page Three"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["text", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--- Page 1 ---"))
+        .stdout(predicate::str::contains("Page One"))
+        .stdout(predicate::str::contains("--- Page 2 ---"))
+        .stdout(predicate::str::contains("Page Two"))
+        .stdout(predicate::str::contains("--- Page 3 ---"))
+        .stdout(predicate::str::contains("Page Three"));
+}
+
+#[test]
+fn text_pages_option_filters_pages() {
+    let pdf_bytes = pdf_with_pages(&["First", "Second", "Third"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["text", f.path().to_str().unwrap(), "--pages", "1,3"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("First"))
+        .stdout(predicate::str::contains("Third"))
+        .stdout(predicate::str::contains("Second").not());
+}
+
+#[test]
+fn text_pages_range_option() {
+    let pdf_bytes = pdf_with_pages(&["A", "B", "C", "D", "E"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["text", f.path().to_str().unwrap(), "--pages", "2-4"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--- Page 2 ---"))
+        .stdout(predicate::str::contains("B"))
+        .stdout(predicate::str::contains("--- Page 3 ---"))
+        .stdout(predicate::str::contains("C"))
+        .stdout(predicate::str::contains("--- Page 4 ---"))
+        .stdout(predicate::str::contains("D"))
+        .stdout(predicate::str::contains("--- Page 1 ---").not());
+}
+
+#[test]
+fn text_layout_flag_accepted() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Layout test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["text", f.path().to_str().unwrap(), "--layout"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Layout test"));
+}
+
+// --- JSON output tests ---
+
+#[test]
+fn text_json_format_outputs_json_lines() {
+    let pdf_bytes = pdf_with_pages(&["Hello", "World"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["text", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Each line should be valid JSON with "page" and "text" fields
+    for line in stdout.lines() {
+        let v: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert!(v.get("page").is_some(), "missing 'page' field");
+        assert!(v.get("text").is_some(), "missing 'text' field");
+    }
+}
+
+#[test]
+fn text_json_format_page_numbers() {
+    let pdf_bytes = pdf_with_pages(&["First", "Second"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["text", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 2);
+
+    let v0: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(v0["page"], 1);
+    assert!(v0["text"].as_str().unwrap().contains("First"));
+
+    let v1: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(v1["page"], 2);
+    assert!(v1["text"].as_str().unwrap().contains("Second"));
+}
+
+// --- Error handling tests ---
+
+#[test]
+fn text_file_not_found_error() {
+    cmd()
+        .args(["text", "nonexistent_file.pdf"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found").or(predicate::str::contains("No such file")));
+}
+
+#[test]
+fn text_invalid_pdf_error() {
+    let mut f = tempfile::Builder::new().suffix(".pdf").tempfile().unwrap();
+    f.write_all(b"this is not a pdf").unwrap();
+    f.flush().unwrap();
+
+    cmd()
+        .args(["text", f.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1);
+}
+
+#[test]
+fn text_invalid_page_range_error() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    // Page 0 is invalid (1-indexed)
+    cmd()
+        .args(["text", f.path().to_str().unwrap(), "--pages", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid"));
+}
+
+#[test]
+fn text_page_out_of_range_error() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    // Only 1 page, but requesting page 99
+    cmd()
+        .args(["text", f.path().to_str().unwrap(), "--pages", "99"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("exceeds"));
+}
+
+#[test]
+fn text_exit_code_zero_on_success() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["text", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .code(0);
+}

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -40,7 +40,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -9,6 +9,9 @@
 - Table has `rows: Vec<Vec<Cell>>`, Cell has `text: Option<String>`
 - Integration tests in `crates/pdfplumber/tests/` use real PDFs from `tests/fixtures/`
 - CLI crate uses `assert_cmd` and `predicates` for integration tests
+- CLI integration tests use `lopdf` + `tempfile` to create PDF fixtures on disk
+- Page range parsing: `parse_page_range("1,3-5", page_count)` → 0-indexed `Vec<usize>`
+- Text command pattern: `text_cmd::run(file, pages, format, layout) -> Result<(), i32>`
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 14시 03분 29초 KST
@@ -28,4 +31,18 @@ Started: 2026년  2월 28일 토요일 14시 03분 29초 KST
   - `assert_cmd::Command::cargo_bin` is deprecated in favor of `cargo::cargo_bin_cmd!` macro but still works
   - clap derive requires `#[command(subcommand)]` on the enum field and `#[derive(Subcommand)]` on the enum
   - Subcommand stubs use `eprintln!` + `std::process::exit(1)` for not-yet-implemented commands
+---
+
+## 2026-02-28 - US-051
+- Implemented `text` subcommand for extracting text from PDF pages
+- Files changed: crates/pdfplumber-cli/{Cargo.toml, src/main.rs, src/text_cmd.rs, src/page_range.rs, tests/text_cmd.rs}
+- New modules: `text_cmd` (text extraction logic), `page_range` (page range parsing)
+- Dependencies added: lopdf (dev), tempfile (dev) — for creating test fixture PDFs
+- Features: text/json output formats, --pages filtering, --layout flag, error handling
+- 8 unit tests (page_range) + 12 integration tests (text_cmd)
+- **Learnings for future iterations:**
+  - `page_range::parse_page_range` is reusable for all subcommands
+  - Test PDF fixtures: use `lopdf` to create PDFs programmatically, `tempfile::NamedTempFile` to write to disk
+  - Error pattern: return `Result<(), i32>` from subcommand handlers where i32 is the exit code
+  - JSON output uses `serde_json::json!` macro with JSON Lines format (one JSON object per line)
 ---


### PR DESCRIPTION
## Summary
- Implement the `text` subcommand that extracts text from PDF pages and outputs to stdout
- Add page range parsing (`--pages 1,3-5`) with 1-indexed input, 0-indexed internal conversion
- Support text and JSON output formats (`--format text|json`)
- Support layout-preserving text extraction (`--layout`)
- Proper error handling: file not found, invalid PDF, invalid/out-of-range page numbers
- Exit code 0 on success, 1 on error

## Key changes
- New module `src/page_range.rs`: reusable page range parser with 8 unit tests
- New module `src/text_cmd.rs`: text extraction command handler
- New test file `tests/text_cmd.rs`: 12 integration tests using lopdf-generated fixture PDFs
- Dev dependencies added: `lopdf`, `tempfile` (for test fixture creation)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 996 tests)
- [x] `cargo check --workspace` passes
- [x] 12 integration tests cover: text extraction, multi-page separators, page filtering, layout flag, JSON format, error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)