### PR TITLE
feat: US-053 - CLI 'words' subcommand - extract words with coordinates

### DIFF
--- a/crates/pdfplumber-cli/src/cli.rs
+++ b/crates/pdfplumber-cli/src/cli.rs
@@ -60,6 +60,14 @@ pub enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
+
+        /// Horizontal tolerance for word grouping (default: 3.0)
+        #[arg(long, default_value_t = 3.0)]
+        x_tolerance: f64,
+
+        /// Vertical tolerance for word grouping (default: 3.0)
+        #[arg(long, default_value_t = 3.0)]
+        y_tolerance: f64,
     },
 
     /// Detect and extract tables from PDF pages
@@ -180,6 +188,46 @@ mod tests {
         match cli.command {
             Commands::Words { ref file, .. } => {
                 assert_eq!(file, &PathBuf::from("test.pdf"));
+            }
+            _ => panic!("expected Words subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_words_with_tolerance_options() {
+        let cli = Cli::parse_from([
+            "pdfplumber",
+            "words",
+            "test.pdf",
+            "--x-tolerance",
+            "5.0",
+            "--y-tolerance",
+            "2.5",
+        ]);
+        match cli.command {
+            Commands::Words {
+                x_tolerance,
+                y_tolerance,
+                ..
+            } => {
+                assert!((x_tolerance - 5.0).abs() < f64::EPSILON);
+                assert!((y_tolerance - 2.5).abs() < f64::EPSILON);
+            }
+            _ => panic!("expected Words subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_words_default_tolerances() {
+        let cli = Cli::parse_from(["pdfplumber", "words", "test.pdf"]);
+        match cli.command {
+            Commands::Words {
+                x_tolerance,
+                y_tolerance,
+                ..
+            } => {
+                assert!((x_tolerance - 3.0).abs() < f64::EPSILON);
+                assert!((y_tolerance - 3.0).abs() < f64::EPSILON);
             }
             _ => panic!("expected Words subcommand"),
         }

--- a/crates/pdfplumber-cli/src/main.rs
+++ b/crates/pdfplumber-cli/src/main.rs
@@ -2,6 +2,7 @@ mod chars_cmd;
 mod cli;
 mod page_range;
 mod text_cmd;
+mod words_cmd;
 
 use clap::Parser;
 use cli::Cli;
@@ -21,10 +22,13 @@ fn main() {
             ref pages,
             ref format,
         } => chars_cmd::run(file, pages.as_deref(), format),
-        cli::Commands::Words { .. } => {
-            eprintln!("words subcommand not yet implemented");
-            Err(1)
-        }
+        cli::Commands::Words {
+            ref file,
+            ref pages,
+            ref format,
+            x_tolerance,
+            y_tolerance,
+        } => words_cmd::run(file, pages.as_deref(), format, x_tolerance, y_tolerance),
         cli::Commands::Tables { .. } => {
             eprintln!("tables subcommand not yet implemented");
             Err(1)

--- a/crates/pdfplumber-cli/src/words_cmd.rs
+++ b/crates/pdfplumber-cli/src/words_cmd.rs
@@ -1,0 +1,144 @@
+use std::path::Path;
+
+use pdfplumber::{Pdf, TextDirection, WordOptions};
+
+use crate::cli::OutputFormat;
+use crate::page_range::parse_page_range;
+
+pub fn run(
+    file: &Path,
+    pages: Option<&str>,
+    format: &OutputFormat,
+    x_tolerance: f64,
+    y_tolerance: f64,
+) -> Result<(), i32> {
+    let pdf = open_pdf(file)?;
+    let page_indices = resolve_pages(pages, pdf.page_count())?;
+
+    let opts = WordOptions {
+        x_tolerance,
+        y_tolerance,
+        ..WordOptions::default()
+    };
+
+    match format {
+        OutputFormat::Text => write_text(&pdf, &page_indices, &opts),
+        OutputFormat::Json => write_json(&pdf, &page_indices, &opts),
+        OutputFormat::Csv => write_csv(&pdf, &page_indices, &opts),
+    }
+}
+
+fn open_pdf(file: &Path) -> Result<Pdf, i32> {
+    if !file.exists() {
+        eprintln!("Error: file not found: {}", file.display());
+        return Err(1);
+    }
+
+    Pdf::open_file(file, None).map_err(|e| {
+        eprintln!("Error: failed to open PDF: {e}");
+        1
+    })
+}
+
+fn resolve_pages(pages: Option<&str>, page_count: usize) -> Result<Vec<usize>, i32> {
+    match pages {
+        Some(range) => parse_page_range(range, page_count).map_err(|e| {
+            eprintln!("Error: {e}");
+            1
+        }),
+        None => Ok((0..page_count).collect()),
+    }
+}
+
+fn direction_str(dir: &TextDirection) -> &'static str {
+    match dir {
+        TextDirection::Ltr => "ltr",
+        TextDirection::Rtl => "rtl",
+        TextDirection::Ttb => "ttb",
+        TextDirection::Btt => "btt",
+    }
+}
+
+fn write_text(pdf: &Pdf, page_indices: &[usize], opts: &WordOptions) -> Result<(), i32> {
+    println!("page\ttext\tx0\ttop\tx1\tbottom\tdoctop\tdirection");
+
+    for &idx in page_indices {
+        let page = pdf.page(idx).map_err(|e| {
+            eprintln!("Error reading page {}: {e}", idx + 1);
+            1
+        })?;
+
+        let words = page.extract_words(opts);
+        for w in &words {
+            println!(
+                "{}\t{}\t{:.2}\t{:.2}\t{:.2}\t{:.2}\t{:.2}\t{}",
+                idx + 1,
+                w.text,
+                w.bbox.x0,
+                w.bbox.top,
+                w.bbox.x1,
+                w.bbox.bottom,
+                w.doctop,
+                direction_str(&w.direction),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn write_json(pdf: &Pdf, page_indices: &[usize], opts: &WordOptions) -> Result<(), i32> {
+    let mut all_words = Vec::new();
+
+    for &idx in page_indices {
+        let page = pdf.page(idx).map_err(|e| {
+            eprintln!("Error reading page {}: {e}", idx + 1);
+            1
+        })?;
+
+        let words = page.extract_words(opts);
+        for w in &words {
+            all_words.push(serde_json::json!({
+                "page": idx + 1,
+                "text": w.text,
+                "x0": w.bbox.x0,
+                "top": w.bbox.top,
+                "x1": w.bbox.x1,
+                "bottom": w.bbox.bottom,
+                "doctop": w.doctop,
+                "direction": direction_str(&w.direction),
+            }));
+        }
+    }
+
+    let json_str = serde_json::to_string(&all_words).unwrap();
+    println!("{json_str}");
+
+    Ok(())
+}
+
+fn write_csv(pdf: &Pdf, page_indices: &[usize], opts: &WordOptions) -> Result<(), i32> {
+    println!("page,text,x0,top,x1,bottom");
+
+    for &idx in page_indices {
+        let page = pdf.page(idx).map_err(|e| {
+            eprintln!("Error reading page {}: {e}", idx + 1);
+            1
+        })?;
+
+        let words = page.extract_words(opts);
+        for w in &words {
+            println!(
+                "{},{},{:.2},{:.2},{:.2},{:.2}",
+                idx + 1,
+                w.text,
+                w.bbox.x0,
+                w.bbox.top,
+                w.bbox.x1,
+                w.bbox.bottom,
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/pdfplumber-cli/tests/words_cmd.rs
+++ b/crates/pdfplumber-cli/tests/words_cmd.rs
@@ -1,0 +1,375 @@
+//! Integration tests for the `words` subcommand (US-053).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+
+fn cmd() -> Command {
+    Command::cargo_bin("pdfplumber").unwrap()
+}
+
+/// Create a single-page PDF with the given content stream using lopdf.
+fn pdf_with_content(content: &[u8]) -> Vec<u8> {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+
+    let stream = Stream::new(dictionary! {}, content.to_vec());
+    let content_id = doc.add_object(stream);
+
+    let resources = dictionary! {
+        "Font" => dictionary! {
+            "F1" => Object::Reference(font_id),
+        },
+    };
+
+    let media_box = vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ];
+    let page_dict = dictionary! {
+        "Type" => "Page",
+        "MediaBox" => media_box,
+        "Contents" => Object::Reference(content_id),
+        "Resources" => resources,
+    };
+    let page_id = doc.add_object(page_dict);
+
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => vec![Object::Reference(page_id)],
+        "Count" => Object::Integer(1),
+    };
+    let pages_id = doc.add_object(pages_dict);
+
+    if let Ok(page_obj) = doc.get_object_mut(page_id) {
+        if let Ok(dict) = page_obj.as_dict_mut() {
+            dict.set("Parent", Object::Reference(pages_id));
+        }
+    }
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).unwrap();
+    buf
+}
+
+/// Create a multi-page PDF. Each page has a single line of text.
+fn pdf_with_pages(texts: &[&str]) -> Vec<u8> {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+
+    let media_box = vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ];
+
+    let mut page_ids = Vec::new();
+    for text in texts {
+        let content_str = format!("BT /F1 12 Tf 72 720 Td ({text}) Tj ET");
+        let stream = Stream::new(dictionary! {}, content_str.into_bytes());
+        let content_id = doc.add_object(stream);
+
+        let resources = dictionary! {
+            "Font" => dictionary! { "F1" => Object::Reference(font_id) },
+        };
+
+        let page_dict = dictionary! {
+            "Type" => "Page",
+            "MediaBox" => media_box.clone(),
+            "Contents" => Object::Reference(content_id),
+            "Resources" => resources,
+        };
+        page_ids.push(doc.add_object(page_dict));
+    }
+
+    let kids: Vec<Object> = page_ids.iter().map(|id| Object::Reference(*id)).collect();
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => kids,
+        "Count" => Object::Integer(texts.len() as i64),
+    };
+    let pages_id = doc.add_object(pages_dict);
+
+    for &pid in &page_ids {
+        if let Ok(page_obj) = doc.get_object_mut(pid) {
+            if let Ok(dict) = page_obj.as_dict_mut() {
+                dict.set("Parent", Object::Reference(pages_id));
+            }
+        }
+    }
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).unwrap();
+    buf
+}
+
+/// Write PDF bytes to a temporary file and return the path.
+fn write_temp_pdf(bytes: &[u8]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new().suffix(".pdf").tempfile().unwrap();
+    f.write_all(bytes).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+// --- Default text format (tab-separated) tests ---
+
+#[test]
+fn words_default_text_format_outputs_tab_separated() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello World) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["words", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Should contain words
+    assert!(stdout.contains("Hello"));
+    assert!(stdout.contains("World"));
+    // Should contain tab characters (TSV format)
+    assert!(stdout.contains('\t'));
+}
+
+#[test]
+fn words_text_format_has_header_line() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["words", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let first_line = stdout.lines().next().unwrap();
+
+    // Header should contain column names
+    assert!(first_line.contains("page"));
+    assert!(first_line.contains("text"));
+    assert!(first_line.contains("x0"));
+    assert!(first_line.contains("top"));
+    assert!(first_line.contains("x1"));
+    assert!(first_line.contains("bottom"));
+}
+
+// --- JSON output tests ---
+
+#[test]
+fn words_json_format_outputs_valid_json_with_all_fields() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello World) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["words", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Output should be valid JSON (array of word objects)
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+    assert!(!arr.is_empty());
+
+    // Check required fields on first word object
+    let word = &arr[0];
+    assert!(word.get("page").is_some(), "missing 'page' field");
+    assert!(word.get("text").is_some(), "missing 'text' field");
+    assert!(word.get("x0").is_some(), "missing 'x0' field");
+    assert!(word.get("top").is_some(), "missing 'top' field");
+    assert!(word.get("x1").is_some(), "missing 'x1' field");
+    assert!(word.get("bottom").is_some(), "missing 'bottom' field");
+    assert!(word.get("doctop").is_some(), "missing 'doctop' field");
+    assert!(word.get("direction").is_some(), "missing 'direction' field");
+}
+
+#[test]
+fn words_json_contains_correct_text_values() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello World) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["words", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+
+    let texts: Vec<&str> = arr.iter().map(|w| w["text"].as_str().unwrap()).collect();
+    assert!(texts.contains(&"Hello"));
+    assert!(texts.contains(&"World"));
+}
+
+// --- CSV output tests ---
+
+#[test]
+fn words_csv_format_outputs_csv_with_header() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["words", f.path().to_str().unwrap(), "--format", "csv"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // First line is CSV header
+    assert!(lines.len() >= 2);
+    let header = lines[0];
+    assert_eq!(header, "page,text,x0,top,x1,bottom");
+
+    // Data line should contain "Test"
+    assert!(lines[1].contains("Test"));
+}
+
+#[test]
+fn words_csv_format_columns_match_header() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello World) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["words", f.path().to_str().unwrap(), "--format", "csv"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    let header_cols = lines[0].split(',').count();
+    for line in &lines[1..] {
+        if line.is_empty() {
+            continue;
+        }
+        assert_eq!(
+            line.split(',').count(),
+            header_cols,
+            "data line column count should match header"
+        );
+    }
+}
+
+// --- Page filtering tests ---
+
+#[test]
+fn words_pages_option_filters_pages() {
+    let pdf_bytes = pdf_with_pages(&["First", "Second", "Third"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args([
+            "words",
+            f.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "--pages",
+            "1,3",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+
+    // Should only have words from pages 1 and 3
+    let pages: std::collections::HashSet<i64> =
+        arr.iter().map(|w| w["page"].as_i64().unwrap()).collect();
+    assert!(pages.contains(&1));
+    assert!(pages.contains(&3));
+    assert!(!pages.contains(&2));
+}
+
+// --- Tolerance options tests ---
+
+#[test]
+fn words_tolerance_options_accepted() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    // Should not error with tolerance options
+    cmd()
+        .args([
+            "words",
+            f.path().to_str().unwrap(),
+            "--x-tolerance",
+            "5.0",
+            "--y-tolerance",
+            "2.0",
+        ])
+        .assert()
+        .success();
+}
+
+// --- Error handling tests ---
+
+#[test]
+fn words_file_not_found_error() {
+    cmd()
+        .args(["words", "nonexistent_file.pdf"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found").or(predicate::str::contains("No such file")));
+}
+
+#[test]
+fn words_invalid_page_range_error() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (X) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["words", f.path().to_str().unwrap(), "--pages", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid"));
+}
+
+#[test]
+fn words_exit_code_zero_on_success() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["words", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .code(0);
+}

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -59,7 +59,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {
@@ -79,7 +79,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -12,6 +12,10 @@
 - CLI integration tests use `lopdf` + `tempfile` to create PDF fixtures on disk
 - Page range parsing: `parse_page_range("1,3-5", page_count)` → 0-indexed `Vec<usize>`
 - Text command pattern: `text_cmd::run(file, pages, format, layout) -> Result<(), i32>`
+- Chars command pattern: `chars_cmd::run(file, pages, format) -> Result<(), i32>`
+- Words command pattern: `words_cmd::run(file, pages, format, x_tolerance, y_tolerance) -> Result<(), i32>`
+- Char bbox accessed via `ch.bbox.x0`, `ch.bbox.top`, etc. (BBox struct wraps coordinates)
+- `page.chars()` returns `&[Char]` (reference to slice), iterate with `for ch in chars` not `&chars`
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 14시 03분 29초 KST
@@ -45,4 +49,34 @@ Started: 2026년  2월 28일 토요일 14시 03분 29초 KST
   - Test PDF fixtures: use `lopdf` to create PDFs programmatically, `tempfile::NamedTempFile` to write to disk
   - Error pattern: return `Result<(), i32>` from subcommand handlers where i32 is the exit code
   - JSON output uses `serde_json::json!` macro with JSON Lines format (one JSON object per line)
+---
+
+## 2026-02-28 - US-052
+- Implemented `chars` subcommand for extracting individual characters with coordinates
+- Files changed: crates/pdfplumber-cli/{src/main.rs, src/chars_cmd.rs, tests/chars_cmd.rs}
+- New module: `chars_cmd` (character extraction logic with text/json/csv output)
+- No new dependencies
+- Features: text (TSV), JSON, CSV output formats; --pages filtering; all Char fields in output
+- 10 integration tests: text format, JSON validity/fields, CSV header/columns, page filtering, error handling
+- **Learnings for future iterations:**
+  - `page.chars()` returns `&[Char]`, not `Vec<Char>` — iterate directly, no extra `&`
+  - BBox fields accessed via `ch.bbox.x0` etc., not directly on Char
+  - TextDirection enum: Ltr, Rtl, Ttb, Btt — convert to lowercase string for output
+  - JSON output uses array format (not JSON Lines) for chars — different from text subcommand
+  - CSV header: `page,text,x0,top,x1,bottom,fontname,size` (8 columns)
+---
+
+## 2026-02-28 - US-053
+- Implemented `words` subcommand for extracting words with bounding box coordinates
+- Files changed: crates/pdfplumber-cli/{src/cli.rs, src/main.rs, src/words_cmd.rs, tests/words_cmd.rs}
+- New module: `words_cmd` (word extraction logic with text/json/csv output)
+- No new dependencies
+- Features: text (TSV), JSON, CSV output formats; --pages filtering; --x-tolerance and --y-tolerance options
+- Added 2 CLI parsing tests (tolerance options + defaults) + 11 integration tests
+- **Learnings for future iterations:**
+  - Words command pattern: `words_cmd::run(file, pages, format, x_tolerance, y_tolerance) -> Result<(), i32>`
+  - `page.extract_words(&opts)` returns `Vec<Word>` (owned), iterate with `for w in &words`
+  - Word fields: text, bbox (x0/top/x1/bottom), doctop, direction — no fontname/size (unlike Char)
+  - CSV header: `page,text,x0,top,x1,bottom` (6 columns, fewer than chars)
+  - Use struct init `WordOptions { x_tolerance, y_tolerance, ..WordOptions::default() }` to avoid clippy field_reassign_with_default
 ---


### PR DESCRIPTION
## Summary
- Implement the `words` subcommand for the pdfplumber CLI that extracts words with bounding box coordinates
- Supports three output formats: text (TSV), JSON, and CSV
- Adds `--x-tolerance` and `--y-tolerance` options for word grouping customization
- Supports `--pages` option for page filtering

## Key Changes
- New `words_cmd` module with text/JSON/CSV output formatting
- Added `--x-tolerance` and `--y-tolerance` CLI options to `Words` variant (default: 3.0)
- Wired `words_cmd::run()` into `main.rs` replacing the stub
- 2 CLI parsing tests + 11 integration tests covering all formats, page filtering, tolerance options, and error handling

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes  
- [x] `cargo test --workspace` passes (all 11 new tests + existing tests)
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)