### PR TITLE
feat: US-056 - CLI metadata and info subcommand

### DIFF
--- a/crates/pdfplumber-cli/src/cli.rs
+++ b/crates/pdfplumber-cli/src/cli.rs
@@ -100,6 +100,21 @@ pub enum Commands {
         #[arg(long, default_value_t = 3.0)]
         text_tolerance: f64,
     },
+
+    /// Display PDF metadata and page information
+    Info {
+        /// Path to the PDF file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Page range (e.g. '1,3-5'). Default: all pages
+        #[arg(long)]
+        pages: Option<String>,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = TextFormat::Text)]
+        format: TextFormat,
+    },
 }
 
 /// Table detection strategy.
@@ -349,6 +364,50 @@ mod tests {
                 assert!(matches!(format, OutputFormat::Text));
             }
             _ => panic!("expected Chars subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_info_subcommand() {
+        let cli = Cli::parse_from(["pdfplumber", "info", "test.pdf"]);
+        match cli.command {
+            Commands::Info { ref file, .. } => {
+                assert_eq!(file, &PathBuf::from("test.pdf"));
+            }
+            _ => panic!("expected Info subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_info_with_json_format() {
+        let cli = Cli::parse_from(["pdfplumber", "info", "test.pdf", "--format", "json"]);
+        match cli.command {
+            Commands::Info { ref format, .. } => {
+                assert!(matches!(format, TextFormat::Json));
+            }
+            _ => panic!("expected Info subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_info_with_pages() {
+        let cli = Cli::parse_from(["pdfplumber", "info", "test.pdf", "--pages", "1-3"]);
+        match cli.command {
+            Commands::Info { ref pages, .. } => {
+                assert_eq!(pages.as_deref(), Some("1-3"));
+            }
+            _ => panic!("expected Info subcommand"),
+        }
+    }
+
+    #[test]
+    fn info_default_format_is_text() {
+        let cli = Cli::parse_from(["pdfplumber", "info", "test.pdf"]);
+        match cli.command {
+            Commands::Info { ref format, .. } => {
+                assert!(matches!(format, TextFormat::Text));
+            }
+            _ => panic!("expected Info subcommand"),
         }
     }
 }

--- a/crates/pdfplumber-cli/src/info_cmd.rs
+++ b/crates/pdfplumber-cli/src/info_cmd.rs
@@ -1,0 +1,90 @@
+use std::path::Path;
+
+use pdfplumber::TableSettings;
+
+use crate::cli::TextFormat;
+use crate::shared::{ProgressReporter, open_pdf, resolve_pages};
+
+pub fn run(file: &Path, pages: Option<&str>, format: &TextFormat) -> Result<(), i32> {
+    let pdf = open_pdf(file)?;
+    let page_count = pdf.page_count();
+    let page_indices = resolve_pages(pages, page_count)?;
+    let progress = ProgressReporter::new(page_indices.len());
+
+    let settings = TableSettings::default();
+
+    let mut total_chars: usize = 0;
+    let mut total_tables: usize = 0;
+    let mut page_infos: Vec<serde_json::Value> = Vec::new();
+
+    for (i, &idx) in page_indices.iter().enumerate() {
+        progress.report(i + 1);
+
+        let page = pdf.page(idx).map_err(|e| {
+            eprintln!("Error reading page {}: {e}", idx + 1);
+            1
+        })?;
+
+        let chars_count = page.chars().len();
+        let lines_count = page.lines().len();
+        let rects_count = page.rects().len();
+        let curves_count = page.curves().len();
+        let images_count = page.images().len();
+        let tables_count = page.find_tables(&settings).len();
+
+        total_chars += chars_count;
+        total_tables += tables_count;
+
+        match format {
+            TextFormat::Text => {
+                println!("Page {}:", idx + 1);
+                println!("  Dimensions: {:.2} x {:.2}", page.width(), page.height());
+                println!("  Rotation: {}°", page.rotation());
+                println!("  Chars: {chars_count}");
+                println!("  Lines: {lines_count}");
+                println!("  Rects: {rects_count}");
+                println!("  Curves: {curves_count}");
+                println!("  Images: {images_count}");
+            }
+            TextFormat::Json => {
+                page_infos.push(serde_json::json!({
+                    "page": idx + 1,
+                    "width": page.width(),
+                    "height": page.height(),
+                    "rotation": page.rotation(),
+                    "chars": chars_count,
+                    "lines": lines_count,
+                    "rects": rects_count,
+                    "curves": curves_count,
+                    "images": images_count,
+                }));
+            }
+        }
+    }
+
+    progress.finish();
+
+    match format {
+        TextFormat::Text => {
+            println!();
+            println!("Pages: {page_count}");
+            println!();
+            println!("Summary:");
+            println!("  Total chars: {total_chars}");
+            println!("  Total tables: {total_tables}");
+        }
+        TextFormat::Json => {
+            let output = serde_json::json!({
+                "pages": page_count,
+                "page_info": page_infos,
+                "summary": {
+                    "total_chars": total_chars,
+                    "total_tables": total_tables,
+                },
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/pdfplumber-cli/src/main.rs
+++ b/crates/pdfplumber-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod chars_cmd;
 mod cli;
+mod info_cmd;
 mod page_range;
 mod shared;
 mod tables_cmd;
@@ -48,6 +49,11 @@ fn main() {
             join_tolerance,
             text_tolerance,
         ),
+        cli::Commands::Info {
+            ref file,
+            ref pages,
+            ref format,
+        } => info_cmd::run(file, pages.as_deref(), format),
     };
 
     if let Err(code) = result {

--- a/crates/pdfplumber-cli/tests/info_cmd.rs
+++ b/crates/pdfplumber-cli/tests/info_cmd.rs
@@ -1,0 +1,427 @@
+//! Integration tests for the `info` subcommand (US-056).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+
+fn cmd() -> Command {
+    Command::cargo_bin("pdfplumber").unwrap()
+}
+
+/// Create a single-page PDF with the given content stream using lopdf.
+fn pdf_with_content(content: &[u8]) -> Vec<u8> {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+
+    let stream = Stream::new(dictionary! {}, content.to_vec());
+    let content_id = doc.add_object(stream);
+
+    let resources = dictionary! {
+        "Font" => dictionary! {
+            "F1" => Object::Reference(font_id),
+        },
+    };
+
+    let media_box = vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ];
+    let page_dict = dictionary! {
+        "Type" => "Page",
+        "MediaBox" => media_box,
+        "Contents" => Object::Reference(content_id),
+        "Resources" => resources,
+    };
+    let page_id = doc.add_object(page_dict);
+
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => vec![Object::Reference(page_id)],
+        "Count" => Object::Integer(1),
+    };
+    let pages_id = doc.add_object(pages_dict);
+
+    if let Ok(page_obj) = doc.get_object_mut(page_id) {
+        if let Ok(dict) = page_obj.as_dict_mut() {
+            dict.set("Parent", Object::Reference(pages_id));
+        }
+    }
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).unwrap();
+    buf
+}
+
+/// Create a multi-page PDF. Each page has a single line of text.
+fn pdf_with_pages(texts: &[&str]) -> Vec<u8> {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+
+    let media_box = vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ];
+
+    let mut page_ids = Vec::new();
+    for text in texts {
+        let content_str = format!("BT /F1 12 Tf 72 720 Td ({text}) Tj ET");
+        let stream = Stream::new(dictionary! {}, content_str.into_bytes());
+        let content_id = doc.add_object(stream);
+
+        let resources = dictionary! {
+            "Font" => dictionary! { "F1" => Object::Reference(font_id) },
+        };
+
+        let page_dict = dictionary! {
+            "Type" => "Page",
+            "MediaBox" => media_box.clone(),
+            "Contents" => Object::Reference(content_id),
+            "Resources" => resources,
+        };
+        page_ids.push(doc.add_object(page_dict));
+    }
+
+    let kids: Vec<Object> = page_ids.iter().map(|id| Object::Reference(*id)).collect();
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => kids,
+        "Count" => Object::Integer(texts.len() as i64),
+    };
+    let pages_id = doc.add_object(pages_dict);
+
+    for &pid in &page_ids {
+        if let Ok(page_obj) = doc.get_object_mut(pid) {
+            if let Ok(dict) = page_obj.as_dict_mut() {
+                dict.set("Parent", Object::Reference(pages_id));
+            }
+        }
+    }
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).unwrap();
+    buf
+}
+
+/// Write PDF bytes to a temporary file and return the path.
+fn write_temp_pdf(bytes: &[u8]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new().suffix(".pdf").tempfile().unwrap();
+    f.write_all(bytes).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+// --- Text output tests ---
+
+#[test]
+fn info_shows_page_count() {
+    let pdf_bytes = pdf_with_pages(&["Hello", "World"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pages: 2"));
+}
+
+#[test]
+fn info_shows_page_dimensions() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("612.00 x 792.00"));
+}
+
+#[test]
+fn info_shows_rotation() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rotation:"));
+}
+
+#[test]
+fn info_shows_object_counts() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hi) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Chars:"))
+        .stdout(predicate::str::contains("Lines:"))
+        .stdout(predicate::str::contains("Rects:"))
+        .stdout(predicate::str::contains("Curves:"))
+        .stdout(predicate::str::contains("Images:"));
+}
+
+#[test]
+fn info_shows_summary() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (ABC) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Summary:"))
+        .stdout(predicate::str::contains("Total chars:"))
+        .stdout(predicate::str::contains("Total tables:"));
+}
+
+#[test]
+fn info_multi_page_shows_each_page() {
+    let pdf_bytes = pdf_with_pages(&["A", "B", "C"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Page 1:"))
+        .stdout(predicate::str::contains("Page 2:"))
+        .stdout(predicate::str::contains("Page 3:"));
+}
+
+// --- Page filtering tests ---
+
+#[test]
+fn info_pages_option_filters_pages() {
+    let pdf_bytes = pdf_with_pages(&["A", "B", "C"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap(), "--pages", "1,3"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Page 1:"))
+        .stdout(predicate::str::contains("Page 3:"))
+        .stdout(predicate::str::contains("Page 2:").not());
+}
+
+// --- JSON output tests ---
+
+#[test]
+fn info_json_format_outputs_valid_json() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["info", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Should be valid JSON
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(v.is_object());
+}
+
+#[test]
+fn info_json_has_required_fields() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["info", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    // Top-level fields
+    assert!(v.get("pages").is_some(), "missing 'pages' field");
+    assert!(v.get("page_info").is_some(), "missing 'page_info' field");
+    assert!(v.get("summary").is_some(), "missing 'summary' field");
+}
+
+#[test]
+fn info_json_page_info_has_all_fields() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["info", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let page_info = v["page_info"].as_array().unwrap();
+    assert_eq!(page_info.len(), 1);
+
+    let page = &page_info[0];
+    assert!(page.get("page").is_some(), "missing 'page'");
+    assert!(page.get("width").is_some(), "missing 'width'");
+    assert!(page.get("height").is_some(), "missing 'height'");
+    assert!(page.get("rotation").is_some(), "missing 'rotation'");
+    assert!(page.get("chars").is_some(), "missing 'chars'");
+    assert!(page.get("lines").is_some(), "missing 'lines'");
+    assert!(page.get("rects").is_some(), "missing 'rects'");
+    assert!(page.get("curves").is_some(), "missing 'curves'");
+    assert!(page.get("images").is_some(), "missing 'images'");
+}
+
+#[test]
+fn info_json_summary_has_totals() {
+    let pdf_bytes = pdf_with_pages(&["Hello", "World"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["info", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let summary = &v["summary"];
+    assert!(
+        summary.get("total_chars").is_some(),
+        "missing 'total_chars'"
+    );
+    assert!(
+        summary.get("total_tables").is_some(),
+        "missing 'total_tables'"
+    );
+}
+
+#[test]
+fn info_json_page_dimensions_are_correct() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (X) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args(["info", f.path().to_str().unwrap(), "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let page = &v["page_info"][0];
+    assert_eq!(page["width"].as_f64().unwrap(), 612.0);
+    assert_eq!(page["height"].as_f64().unwrap(), 792.0);
+    assert_eq!(page["page"].as_u64().unwrap(), 1);
+}
+
+#[test]
+fn info_json_pages_filter_works() {
+    let pdf_bytes = pdf_with_pages(&["A", "B", "C"]);
+    let f = write_temp_pdf(&pdf_bytes);
+
+    let output = cmd()
+        .args([
+            "info",
+            f.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "--pages",
+            "2",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let page_info = v["page_info"].as_array().unwrap();
+    assert_eq!(page_info.len(), 1);
+    assert_eq!(page_info[0]["page"].as_u64().unwrap(), 2);
+}
+
+// --- Error handling tests ---
+
+#[test]
+fn info_file_not_found_error() {
+    cmd()
+        .args(["info", "nonexistent_file.pdf"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found").or(predicate::str::contains("No such file")));
+}
+
+#[test]
+fn info_invalid_pdf_error() {
+    let mut f = tempfile::Builder::new().suffix(".pdf").tempfile().unwrap();
+    f.write_all(b"this is not a pdf").unwrap();
+    f.flush().unwrap();
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1);
+}
+
+#[test]
+fn info_invalid_page_range_error() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap(), "--pages", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid"));
+}
+
+#[test]
+fn info_exit_code_zero_on_success() {
+    let pdf_bytes = pdf_with_content(b"BT /F1 12 Tf 72 720 Td (Test) Tj ET");
+    let f = write_temp_pdf(&pdf_bytes);
+
+    cmd()
+        .args(["info", f.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .code(0);
+}

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -137,7 +137,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 7,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -20,6 +20,8 @@
 - `page.find_tables(&settings)` returns `Vec<Table>`, Table has `bbox`, `rows`, `cells`, `columns`
 - Table.rows is `Vec<Vec<Cell>>`, Cell has `text: Option<String>` and `bbox: BBox`
 - Strategy/TableSettings re-exported from pdfplumber facade crate
+- Info command pattern: `info_cmd::run(file, pages, format) -> Result<(), i32>`
+- Page dimension/count API: `page.width()`, `page.height()`, `page.rotation()`, `page.chars().len()`, `page.lines().len()`, `page.rects().len()`, `page.curves().len()`, `page.images().len()`
 - Shared utilities in `shared.rs`: `open_pdf`, `resolve_pages`, `direction_str`, `csv_escape`, `ProgressReporter`
 - ProgressReporter: `new(total)`, `report(current)`, `finish()` — only prints to stderr when TTY
 - `Pdf` doesn't implement `Debug` — can't use `unwrap_err()` on `Result<Pdf, i32>`
@@ -121,4 +123,18 @@ Started: 2026년  2월 28일 토요일 14시 03분 29초 KST
   - Rust import ordering: rustfmt sorts identifiers alphabetically, so `ProgressReporter` comes before `direction_str`
   - `std::io::IsTerminal` trait provides `is_terminal()` method for TTY detection (stabilized in Rust 1.70)
   - Shared module pattern: extract common functions into `shared.rs`, import with `use crate::shared::{...}`
+---
+
+## 2026-02-28 - US-056
+- Implemented `info` subcommand for displaying PDF metadata and page information
+- Files changed: src/cli.rs (added Info variant + 4 CLI parsing tests), src/main.rs (wired info_cmd), src/info_cmd.rs (new), tests/info_cmd.rs (new)
+- No new dependencies
+- Features: text and JSON output formats, --pages filtering, per-page details (dimensions, rotation, object counts), total document summary (chars, tables)
+- 4 CLI parsing tests + 17 integration tests (text output, JSON structure, page filtering, error handling)
+- **Learnings for future iterations:**
+  - Info command pattern: `info_cmd::run(file, pages, format) -> Result<(), i32>`
+  - Page API: `page.width()`, `page.height()`, `page.rotation()` for dimensions; `.chars().len()`, `.lines().len()`, `.rects().len()`, `.curves().len()`, `.images().len()` for object counts
+  - `page.find_tables(&settings).len()` for table count — reuses TableSettings::default()
+  - Info uses `TextFormat` (text/json) from cli.rs — same as text subcommand, no CSV needed
+  - JSON output uses `serde_json::to_string_pretty` for human-readable structured output (unlike JSON Lines in text cmd)
 ---


### PR DESCRIPTION
## Summary
- Add `info` subcommand to display PDF metadata and page information
- Supports text and JSON output formats with `--format` option
- `--pages` option for filtering which pages to inspect
- Displays per-page: dimensions (width x height), rotation, object counts (chars, lines, rects, curves, images)
- Includes total document summary: total chars, total tables detected

## Test plan
- [x] 4 CLI parsing unit tests (subcommand parsing, format, pages, default format)
- [x] 17 integration tests covering:
  - Text output: page count, dimensions, rotation, object counts, summary, multi-page
  - JSON output: valid JSON, required fields, page_info fields, summary totals, dimension values, page filtering
  - Error handling: file not found, invalid PDF, invalid page range, exit code
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 400+ tests)
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)