### PR TITLE
feat: US-057 - CLI crates.io publishing preparation

### DIFF
--- a/crates/pdfplumber-cli/README.md
+++ b/crates/pdfplumber-cli/README.md
@@ -1,0 +1,176 @@
+# pdfplumber-cli
+
+Command-line tool to extract text, characters, words, and tables from PDF documents.
+
+**pdfplumber-cli** is the CLI frontend for [pdfplumber-rs](https://github.com/developer0hye/pdfplumber-rs), a Rust port of Python's [pdfplumber](https://github.com/jsvine/pdfplumber).
+
+## Installation
+
+```bash
+cargo install pdfplumber-cli
+```
+
+## Usage
+
+```bash
+pdfplumber <COMMAND> [OPTIONS] <FILE>
+```
+
+### Subcommands
+
+| Command  | Description                                      |
+|----------|--------------------------------------------------|
+| `text`   | Extract text from PDF pages                      |
+| `chars`  | Extract individual characters with coordinates   |
+| `words`  | Extract words with bounding box coordinates      |
+| `tables` | Detect and extract tables from PDF pages         |
+| `info`   | Display PDF metadata and page information        |
+
+### Global Options
+
+| Option      | Description                              |
+|-------------|------------------------------------------|
+| `--version` | Print version number                     |
+| `--help`    | Print help information                   |
+
+### Extract Text
+
+```bash
+# Extract all text
+pdfplumber text document.pdf
+
+# Extract text from specific pages
+pdfplumber text document.pdf --pages 1,3-5
+
+# Layout-preserving extraction
+pdfplumber text document.pdf --layout
+
+# JSON output (one object per page)
+pdfplumber text document.pdf --format json
+```
+
+### Extract Characters
+
+```bash
+# Tab-separated output (default)
+pdfplumber chars document.pdf
+
+# JSON output with all fields (text, fontname, size, bbox, etc.)
+pdfplumber chars document.pdf --format json
+
+# CSV output
+pdfplumber chars document.pdf --format csv --pages 1
+```
+
+Example CSV output:
+
+```
+page,text,x0,top,x1,bottom,fontname,size
+1,H,72.00,72.00,84.00,84.00,Helvetica,12.00
+1,e,84.00,72.00,90.72,84.00,Helvetica,12.00
+```
+
+### Extract Words
+
+```bash
+# Tab-separated output (default)
+pdfplumber words document.pdf
+
+# JSON output
+pdfplumber words document.pdf --format json
+
+# CSV output with custom tolerances
+pdfplumber words document.pdf --format csv --x-tolerance 5.0 --y-tolerance 2.5
+```
+
+Example CSV output:
+
+```
+page,text,x0,top,x1,bottom
+1,Hello,72.00,72.00,108.00,84.00
+1,World,112.00,72.00,148.00,84.00
+```
+
+### Extract Tables
+
+```bash
+# Human-readable grid format (default)
+pdfplumber tables document.pdf
+
+# JSON output
+pdfplumber tables document.pdf --format json
+
+# CSV output
+pdfplumber tables document.pdf --format csv
+
+# Use stream strategy instead of lattice
+pdfplumber tables document.pdf --strategy stream
+
+# Tune detection parameters
+pdfplumber tables document.pdf --snap-tolerance 5.0 --join-tolerance 4.0 --text-tolerance 2.0
+```
+
+Example grid output:
+
+```
+--- Table 1 (page 1, bbox: [72.00, 100.00, 540.00, 300.00]) ---
+Name   | Age | City
+Alice  | 30  | New York
+Bob    | 25  | London
+```
+
+### Inspect PDF Info
+
+```bash
+# Text summary
+pdfplumber info document.pdf
+
+# JSON output
+pdfplumber info document.pdf --format json
+
+# Specific pages only
+pdfplumber info document.pdf --pages 1-3
+```
+
+Example text output:
+
+```
+=== PDF Info ===
+Pages: 3
+
+--- Page 1 (612.00 x 792.00, rotation: 0°) ---
+  Chars:  1250
+  Lines:  45
+  Rects:  12
+  Curves: 0
+  Images: 2
+
+=== Summary ===
+Total chars:  3200
+Total tables: 1
+```
+
+## Output Formats
+
+| Subcommand | text (default) | json | csv |
+|------------|---------------|------|-----|
+| `text`     | Plain text    | JSON lines | — |
+| `chars`    | TSV           | JSON array | CSV |
+| `words`    | TSV           | JSON array | CSV |
+| `tables`   | Grid          | JSON array | CSV |
+| `info`     | Summary       | JSON       | — |
+
+## Page Selection
+
+Use `--pages` to select specific pages (1-indexed):
+
+- `--pages 1` — single page
+- `--pages 1-5` — range
+- `--pages 1,3,5` — list
+- `--pages 1-3,7,10-12` — mixed
+
+Omit `--pages` to process all pages.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/pdfplumber-cli/tests/cli_args.rs
+++ b/crates/pdfplumber-cli/tests/cli_args.rs
@@ -62,6 +62,35 @@ fn tables_subcommand_help() {
 }
 
 #[test]
+fn version_flag_prints_version() {
+    cmd()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pdfplumber 0.1.0"));
+}
+
+#[test]
+fn info_subcommand_help() {
+    cmd()
+        .args(["info", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FILE"))
+        .stdout(predicate::str::contains("--pages"))
+        .stdout(predicate::str::contains("--format"));
+}
+
+#[test]
+fn help_lists_info_subcommand() {
+    cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("info"));
+}
+
+#[test]
 fn no_args_shows_help() {
     // Running with no subcommand should show usage / error
     cmd()

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -155,7 +155,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 8,
-      "passes": false,
+      "passes": true,
       "notes": "Final story - after this, the CLI is ready for publication."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -138,3 +138,19 @@ Started: 2026년  2월 28일 토요일 14시 03분 29초 KST
   - Info uses `TextFormat` (text/json) from cli.rs — same as text subcommand, no CSV needed
   - JSON output uses `serde_json::to_string_pretty` for human-readable structured output (unlike JSON Lines in text cmd)
 ---
+
+## 2026-02-28 - US-057
+- Prepared pdfplumber-cli for crates.io publishing
+- Verified all Cargo.toml metadata: description, license, repository, keywords, categories (already set in earlier stories)
+- Version 0.1.0 matches workspace crates; version dependency on pdfplumber crate already configured
+- Created README.md with: installation (`cargo install pdfplumber-cli`), usage examples for all 5 subcommands, output format examples, page selection docs
+- Added 3 integration tests: --version flag, info subcommand --help, help lists info subcommand
+- `cargo publish --dry-run -p pdfplumber-cli` succeeds (20 files packaged, ~26KB compressed)
+- `pdfplumber --version` prints "pdfplumber 0.1.0"
+- Files changed: crates/pdfplumber-cli/{README.md (new), tests/cli_args.rs (3 new tests)}
+- No new dependencies
+- **Learnings for future iterations:**
+  - `cargo publish --dry-run` requires committed changes (use `--allow-dirty` for pre-commit verification)
+  - Most metadata was already in place from US-050 scaffolding — workspace inheritance covers license/repository
+  - clap's `#[command(version)]` attribute automatically uses `env!("CARGO_PKG_VERSION")`
+---


### PR DESCRIPTION
## Summary
- Prepared `pdfplumber-cli` for crates.io publishing with proper metadata, README, and version alignment
- Created comprehensive README.md with installation instructions, usage examples for all 5 subcommands, output format documentation, and page selection guide
- Added integration tests for `--version` flag and `info` subcommand help
- Verified `cargo publish --dry-run -p pdfplumber-cli` succeeds (20 files, ~26KB compressed)

## Key Changes
- `crates/pdfplumber-cli/README.md` — New: installation, usage examples, output format table
- `crates/pdfplumber-cli/tests/cli_args.rs` — 3 new tests: version flag, info help, help lists info
- `scripts/ralph/prd.json` — Marked US-057 as passes: true
- `scripts/ralph/progress.txt` — Added US-057 progress entry

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all tests green)
- [x] `cargo check --workspace` passes
- [x] `cargo publish --dry-run -p pdfplumber-cli` succeeds
- [x] `pdfplumber --version` prints "pdfplumber 0.1.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)