### PR TITLE
feat: US-062 - Bookmark / Outline / ToC extraction

### DIFF
--- a/crates/pdfplumber-cli/src/bookmarks_cmd.rs
+++ b/crates/pdfplumber-cli/src/bookmarks_cmd.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+
+use pdfplumber::Bookmark;
+
+use crate::cli::TextFormat;
+use crate::shared::open_pdf;
+
+pub fn run(file: &Path, format: &TextFormat) -> Result<(), i32> {
+    let pdf = open_pdf(file)?;
+    let bookmarks = pdf.bookmarks();
+
+    match format {
+        TextFormat::Text => write_text(bookmarks),
+        TextFormat::Json => write_json(bookmarks),
+    }
+}
+
+fn write_text(bookmarks: &[Bookmark]) -> Result<(), i32> {
+    if bookmarks.is_empty() {
+        println!("No bookmarks found.");
+        return Ok(());
+    }
+
+    println!("level\tpage\ttitle");
+
+    for bm in bookmarks {
+        let indent = "  ".repeat(bm.level);
+        let page_str = match bm.page_number {
+            Some(p) => (p + 1).to_string(),
+            None => "-".to_string(),
+        };
+        println!("{}\t{}\t{}{}", bm.level, page_str, indent, bm.title);
+    }
+
+    Ok(())
+}
+
+fn write_json(bookmarks: &[Bookmark]) -> Result<(), i32> {
+    let json_values: Vec<serde_json::Value> = bookmarks
+        .iter()
+        .map(|bm| {
+            let mut obj = serde_json::json!({
+                "title": bm.title,
+                "level": bm.level,
+            });
+            if let Some(page) = bm.page_number {
+                obj["page_number"] = serde_json::json!(page);
+            }
+            if let Some(top) = bm.dest_top {
+                obj["dest_top"] = serde_json::json!(top);
+            }
+            obj
+        })
+        .collect();
+
+    let json_str = serde_json::to_string(&json_values).unwrap();
+    println!("{json_str}");
+
+    Ok(())
+}

--- a/crates/pdfplumber-cli/src/cli.rs
+++ b/crates/pdfplumber-cli/src/cli.rs
@@ -145,6 +145,17 @@ pub enum Commands {
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
     },
+
+    /// Extract bookmarks (outline / table of contents) from PDF
+    Bookmarks {
+        /// Path to the PDF file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = TextFormat::Text)]
+        format: TextFormat,
+    },
 }
 
 /// Table detection strategy.
@@ -504,6 +515,39 @@ mod tests {
                 assert!(matches!(format, OutputFormat::Text));
             }
             _ => panic!("expected Links subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_bookmarks_subcommand() {
+        let cli = Cli::parse_from(["pdfplumber", "bookmarks", "test.pdf"]);
+        match cli.command {
+            Commands::Bookmarks { ref file, .. } => {
+                assert_eq!(file, &PathBuf::from("test.pdf"));
+            }
+            _ => panic!("expected Bookmarks subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_bookmarks_with_json_format() {
+        let cli = Cli::parse_from(["pdfplumber", "bookmarks", "test.pdf", "--format", "json"]);
+        match cli.command {
+            Commands::Bookmarks { ref format, .. } => {
+                assert!(matches!(format, TextFormat::Json));
+            }
+            _ => panic!("expected Bookmarks subcommand"),
+        }
+    }
+
+    #[test]
+    fn bookmarks_default_format_is_text() {
+        let cli = Cli::parse_from(["pdfplumber", "bookmarks", "test.pdf"]);
+        match cli.command {
+            Commands::Bookmarks { ref format, .. } => {
+                assert!(matches!(format, TextFormat::Text));
+            }
+            _ => panic!("expected Bookmarks subcommand"),
         }
     }
 }

--- a/crates/pdfplumber-cli/src/main.rs
+++ b/crates/pdfplumber-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod annots_cmd;
+mod bookmarks_cmd;
 mod chars_cmd;
 mod cli;
 mod info_cmd;
@@ -66,6 +67,10 @@ fn main() {
             ref pages,
             ref format,
         } => links_cmd::run(file, pages.as_deref(), format),
+        cli::Commands::Bookmarks {
+            ref file,
+            ref format,
+        } => bookmarks_cmd::run(file, format),
     };
 
     if let Err(code) = result {

--- a/crates/pdfplumber-cli/tests/bookmarks_cmd.rs
+++ b/crates/pdfplumber-cli/tests/bookmarks_cmd.rs
@@ -1,0 +1,187 @@
+//! Integration tests for the `bookmarks` subcommand (US-062).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+
+fn cmd() -> Command {
+    Command::cargo_bin("pdfplumber").unwrap()
+}
+
+/// Create a PDF with multi-level bookmarks.
+fn pdf_with_bookmarks() -> Vec<u8> {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+
+    let media_box = vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ];
+
+    let mut page_ids = Vec::new();
+    for text in &["Chapter 1", "Chapter 2"] {
+        let content_str = format!("BT /F1 12 Tf 72 720 Td ({text}) Tj ET");
+        let stream = Stream::new(dictionary! {}, content_str.into_bytes());
+        let content_id = doc.add_object(stream);
+        let resources = dictionary! {
+            "Font" => dictionary! { "F1" => Object::Reference(font_id) },
+        };
+        let page_dict = dictionary! {
+            "Type" => "Page",
+            "MediaBox" => media_box.clone(),
+            "Contents" => Object::Reference(content_id),
+            "Resources" => resources,
+        };
+        page_ids.push(doc.add_object(page_dict));
+    }
+
+    let kids: Vec<Object> = page_ids.iter().map(|id| Object::Reference(*id)).collect();
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => kids,
+        "Count" => Object::Integer(2),
+    };
+    let pages_id = doc.add_object(pages_dict);
+
+    for &pid in &page_ids {
+        if let Ok(page_obj) = doc.get_object_mut(pid) {
+            if let Ok(dict) = page_obj.as_dict_mut() {
+                dict.set("Parent", Object::Reference(pages_id));
+            }
+        }
+    }
+
+    // Create outline: Chapter 1 → page 1, Chapter 2 → page 2
+    let ch1_id = doc.add_object(dictionary! {
+        "Title" => Object::string_literal("Chapter 1"),
+        "Dest" => vec![Object::Reference(page_ids[0]), Object::Name(b"Fit".to_vec())],
+    });
+    let ch2_id = doc.add_object(dictionary! {
+        "Title" => Object::string_literal("Chapter 2"),
+        "Dest" => vec![Object::Reference(page_ids[1]), Object::Name(b"Fit".to_vec())],
+    });
+
+    if let Ok(obj) = doc.get_object_mut(ch1_id) {
+        if let Ok(dict) = obj.as_dict_mut() {
+            dict.set("Next", Object::Reference(ch2_id));
+        }
+    }
+    if let Ok(obj) = doc.get_object_mut(ch2_id) {
+        if let Ok(dict) = obj.as_dict_mut() {
+            dict.set("Prev", Object::Reference(ch1_id));
+        }
+    }
+
+    let outlines_id = doc.add_object(dictionary! {
+        "Type" => "Outlines",
+        "First" => Object::Reference(ch1_id),
+        "Last" => Object::Reference(ch2_id),
+        "Count" => Object::Integer(2),
+    });
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+        "Outlines" => Object::Reference(outlines_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut buf = Vec::new();
+    doc.save_to(&mut buf).unwrap();
+    buf
+}
+
+#[test]
+fn bookmarks_text_format_shows_entries() {
+    let bytes = pdf_with_bookmarks();
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&bytes).unwrap();
+
+    cmd()
+        .args(["bookmarks", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Chapter 1"))
+        .stdout(predicate::str::contains("Chapter 2"));
+}
+
+#[test]
+fn bookmarks_json_format_shows_entries() {
+    let bytes = pdf_with_bookmarks();
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&bytes).unwrap();
+
+    cmd()
+        .args([
+            "bookmarks",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"title\":\"Chapter 1\""))
+        .stdout(predicate::str::contains("\"title\":\"Chapter 2\""));
+}
+
+#[test]
+fn bookmarks_no_outlines() {
+    use lopdf::{Object, Stream, dictionary};
+
+    let mut doc = lopdf::Document::with_version("1.5");
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+    });
+    let stream = Stream::new(
+        dictionary! {},
+        b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET".to_vec(),
+    );
+    let content_id = doc.add_object(stream);
+    let resources = dictionary! { "Font" => dictionary! { "F1" => Object::Reference(font_id) } };
+    let page_dict = dictionary! {
+        "Type" => "Page",
+        "MediaBox" => vec![Object::Integer(0), Object::Integer(0), Object::Integer(612), Object::Integer(792)],
+        "Contents" => Object::Reference(content_id),
+        "Resources" => resources,
+    };
+    let page_id = doc.add_object(page_dict);
+    let pages_dict = dictionary! {
+        "Type" => "Pages",
+        "Kids" => vec![Object::Reference(page_id)],
+        "Count" => Object::Integer(1),
+    };
+    let pages_id = doc.add_object(pages_dict);
+    if let Ok(page_obj) = doc.get_object_mut(page_id) {
+        if let Ok(dict) = page_obj.as_dict_mut() {
+            dict.set("Parent", Object::Reference(pages_id));
+        }
+    }
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&bytes).unwrap();
+
+    cmd()
+        .args(["bookmarks", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No bookmarks found."));
+}

--- a/crates/pdfplumber-core/src/bookmark.rs
+++ b/crates/pdfplumber-core/src/bookmark.rs
@@ -1,0 +1,102 @@
+//! PDF bookmark / outline / table of contents types.
+//!
+//! Provides [`Bookmark`] for representing entries in the PDF document outline
+//! tree (bookmarks / table of contents).
+
+/// A single entry in the PDF document outline (bookmark / table of contents).
+///
+/// Bookmarks are extracted from the `/Outlines` dictionary in the PDF catalog.
+/// Each bookmark has a title, a nesting level, and optionally a destination
+/// page number and y-coordinate.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Bookmark {
+    /// The bookmark title text.
+    pub title: String,
+    /// Nesting depth (0-indexed). Top-level bookmarks have level 0.
+    pub level: usize,
+    /// The 0-indexed destination page number, if resolvable.
+    pub page_number: Option<usize>,
+    /// The y-coordinate on the destination page (top of view), if available.
+    pub dest_top: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bookmark_with_all_fields() {
+        let bm = Bookmark {
+            title: "Chapter 1".to_string(),
+            level: 0,
+            page_number: Some(0),
+            dest_top: Some(792.0),
+        };
+        assert_eq!(bm.title, "Chapter 1");
+        assert_eq!(bm.level, 0);
+        assert_eq!(bm.page_number, Some(0));
+        assert_eq!(bm.dest_top, Some(792.0));
+    }
+
+    #[test]
+    fn bookmark_without_destination() {
+        let bm = Bookmark {
+            title: "Appendix".to_string(),
+            level: 1,
+            page_number: None,
+            dest_top: None,
+        };
+        assert_eq!(bm.title, "Appendix");
+        assert_eq!(bm.level, 1);
+        assert!(bm.page_number.is_none());
+        assert!(bm.dest_top.is_none());
+    }
+
+    #[test]
+    fn bookmark_clone_and_eq() {
+        let bm1 = Bookmark {
+            title: "Section 2.1".to_string(),
+            level: 2,
+            page_number: Some(5),
+            dest_top: Some(500.0),
+        };
+        let bm2 = bm1.clone();
+        assert_eq!(bm1, bm2);
+    }
+
+    #[test]
+    fn bookmark_nested_levels() {
+        let bookmarks = vec![
+            Bookmark {
+                title: "Chapter 1".to_string(),
+                level: 0,
+                page_number: Some(0),
+                dest_top: None,
+            },
+            Bookmark {
+                title: "Section 1.1".to_string(),
+                level: 1,
+                page_number: Some(2),
+                dest_top: None,
+            },
+            Bookmark {
+                title: "Section 1.1.1".to_string(),
+                level: 2,
+                page_number: Some(3),
+                dest_top: None,
+            },
+            Bookmark {
+                title: "Chapter 2".to_string(),
+                level: 0,
+                page_number: Some(10),
+                dest_top: None,
+            },
+        ];
+        assert_eq!(bookmarks.len(), 4);
+        assert_eq!(bookmarks[0].level, 0);
+        assert_eq!(bookmarks[1].level, 1);
+        assert_eq!(bookmarks[2].level, 2);
+        assert_eq!(bookmarks[3].level, 0);
+    }
+}

--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -24,6 +24,8 @@
 
 /// PDF annotation types.
 pub mod annotation;
+/// PDF bookmark / outline / table of contents types.
+pub mod bookmark;
 /// Edge derivation from geometric primitives for table detection.
 pub mod edges;
 /// Font encoding mapping (Standard, Windows, Mac, Custom).
@@ -54,6 +56,7 @@ pub mod text;
 pub mod words;
 
 pub use annotation::{Annotation, AnnotationType};
+pub use bookmark::Bookmark;
 pub use edges::{Edge, EdgeSource, derive_edges, edge_from_curve, edge_from_line, edges_from_rect};
 pub use encoding::{EncodingResolver, FontEncoding, StandardEncoding};
 pub use error::{ExtractOptions, ExtractResult, ExtractWarning, PdfError};

--- a/crates/pdfplumber-parse/src/backend.rs
+++ b/crates/pdfplumber-parse/src/backend.rs
@@ -3,7 +3,9 @@
 //! Defines the [`PdfBackend`] trait that abstracts PDF parsing operations.
 //! This enables pluggable backends (e.g., lopdf, pdf-rs) for PDF reading.
 
-use pdfplumber_core::{Annotation, BBox, DocumentMetadata, ExtractOptions, Hyperlink, PdfError};
+use pdfplumber_core::{
+    Annotation, BBox, Bookmark, DocumentMetadata, ExtractOptions, Hyperlink, PdfError,
+};
 
 use crate::handler::ContentHandler;
 
@@ -130,6 +132,17 @@ pub trait PdfBackend {
     ///
     /// Returns an error if the /Info dictionary exists but is malformed.
     fn document_metadata(doc: &Self::Document) -> Result<DocumentMetadata, Self::Error>;
+
+    /// Extract the document outline (bookmarks / table of contents).
+    ///
+    /// Returns a flat list of [`Bookmark`]s representing the outline tree,
+    /// with each bookmark's `level` indicating its depth. Returns an empty
+    /// Vec if the document has no /Outlines dictionary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the /Outlines dictionary exists but is malformed.
+    fn document_bookmarks(doc: &Self::Document) -> Result<Vec<Bookmark>, Self::Error>;
 
     /// Extract annotations from a page.
     ///
@@ -318,6 +331,10 @@ mod tests {
 
         fn document_metadata(_doc: &Self::Document) -> Result<DocumentMetadata, Self::Error> {
             Ok(DocumentMetadata::default())
+        }
+
+        fn document_bookmarks(_doc: &Self::Document) -> Result<Vec<Bookmark>, Self::Error> {
+            Ok(Vec::new())
         }
 
         fn page_annotations(

--- a/crates/pdfplumber-parse/src/lopdf_backend.rs
+++ b/crates/pdfplumber-parse/src/lopdf_backend.rs
@@ -7,7 +7,7 @@ use crate::backend::PdfBackend;
 use crate::error::BackendError;
 use crate::handler::ContentHandler;
 use pdfplumber_core::{
-    Annotation, AnnotationType, BBox, DocumentMetadata, ExtractOptions, Hyperlink,
+    Annotation, AnnotationType, BBox, Bookmark, DocumentMetadata, ExtractOptions, Hyperlink,
 };
 
 /// A parsed PDF document backed by lopdf.
@@ -231,6 +231,10 @@ impl PdfBackend for LopdfBackend {
         extract_document_metadata(&doc.inner)
     }
 
+    fn document_bookmarks(doc: &Self::Document) -> Result<Vec<Bookmark>, Self::Error> {
+        extract_document_bookmarks(&doc.inner)
+    }
+
     fn page_annotations(
         doc: &Self::Document,
         page: &Self::Page,
@@ -439,6 +443,432 @@ fn extract_document_metadata(doc: &lopdf::Document) -> Result<DocumentMetadata, 
         creation_date: extract_string_from_dict(doc, info_dict, b"CreationDate"),
         mod_date: extract_string_from_dict(doc, info_dict, b"ModDate"),
     })
+}
+
+/// Extract the document outline (bookmarks / table of contents) from the PDF catalog.
+///
+/// Walks the `/Outlines` tree using `/First`, `/Next` sibling links,
+/// resolving destinations to page numbers and y-coordinates.
+fn extract_document_bookmarks(doc: &lopdf::Document) -> Result<Vec<Bookmark>, BackendError> {
+    // Get the catalog dictionary
+    let catalog_ref = match doc.trailer.get(b"Root") {
+        Ok(obj) => obj,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let catalog = match catalog_ref {
+        lopdf::Object::Reference(id) => match doc.get_object(*id) {
+            Ok(obj) => match obj.as_dict() {
+                Ok(dict) => dict,
+                Err(_) => return Ok(Vec::new()),
+            },
+            Err(_) => return Ok(Vec::new()),
+        },
+        lopdf::Object::Dictionary(dict) => dict,
+        _ => return Ok(Vec::new()),
+    };
+
+    // Get /Outlines dictionary
+    let outlines_obj = match catalog.get(b"Outlines") {
+        Ok(obj) => obj,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let outlines_obj = match outlines_obj {
+        lopdf::Object::Reference(id) => match doc.get_object(*id) {
+            Ok(obj) => obj,
+            Err(_) => return Ok(Vec::new()),
+        },
+        other => other,
+    };
+
+    let outlines_dict = match outlines_obj.as_dict() {
+        Ok(dict) => dict,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    // Get /First child of the outlines root
+    let first_ref = match outlines_dict.get(b"First") {
+        Ok(lopdf::Object::Reference(id)) => *id,
+        _ => return Ok(Vec::new()),
+    };
+
+    // Build page map for resolving destinations
+    let pages_map = doc.get_pages();
+
+    let mut bookmarks = Vec::new();
+    let max_depth = 64; // Prevent circular references
+    walk_outline_tree(doc, first_ref, 0, max_depth, &pages_map, &mut bookmarks);
+
+    Ok(bookmarks)
+}
+
+/// Recursively walk the outline tree, collecting bookmarks.
+fn walk_outline_tree(
+    doc: &lopdf::Document,
+    item_id: lopdf::ObjectId,
+    level: usize,
+    max_depth: usize,
+    pages_map: &std::collections::BTreeMap<u32, lopdf::ObjectId>,
+    bookmarks: &mut Vec<Bookmark>,
+) {
+    if level >= max_depth {
+        return;
+    }
+
+    let mut current_id = Some(item_id);
+    let mut visited = std::collections::HashSet::new();
+    let max_siblings = 10_000; // Safety limit on siblings at one level
+    let mut sibling_count = 0;
+
+    while let Some(node_id) = current_id {
+        // Circular reference protection
+        if !visited.insert(node_id) || sibling_count >= max_siblings {
+            break;
+        }
+        sibling_count += 1;
+
+        let node_obj = match doc.get_object(node_id) {
+            Ok(obj) => obj,
+            Err(_) => break,
+        };
+
+        let node_dict = match node_obj.as_dict() {
+            Ok(dict) => dict,
+            Err(_) => break,
+        };
+
+        // Extract /Title
+        let title = extract_string_from_dict(doc, node_dict, b"Title").unwrap_or_default();
+
+        // Resolve destination (page number and y-coordinate)
+        let (page_number, dest_top) = resolve_bookmark_dest(doc, node_dict, pages_map);
+
+        bookmarks.push(Bookmark {
+            title,
+            level,
+            page_number,
+            dest_top,
+        });
+
+        // Recurse into children (/First)
+        if let Ok(lopdf::Object::Reference(child_id)) = node_dict.get(b"First") {
+            walk_outline_tree(doc, *child_id, level + 1, max_depth, pages_map, bookmarks);
+        }
+
+        // Move to next sibling (/Next)
+        current_id = match node_dict.get(b"Next") {
+            Ok(lopdf::Object::Reference(next_id)) => Some(*next_id),
+            _ => None,
+        };
+    }
+}
+
+/// Resolve a bookmark's destination to (page_number, dest_top).
+///
+/// Checks /Dest first, then /A (GoTo action).
+fn resolve_bookmark_dest(
+    doc: &lopdf::Document,
+    node_dict: &lopdf::Dictionary,
+    pages_map: &std::collections::BTreeMap<u32, lopdf::ObjectId>,
+) -> (Option<usize>, Option<f64>) {
+    // Try /Dest first
+    if let Ok(dest_obj) = node_dict.get(b"Dest") {
+        if let Some(result) = resolve_dest_to_page(doc, dest_obj, pages_map) {
+            return result;
+        }
+    }
+
+    // Try /A (Action) dictionary — only GoTo actions
+    if let Ok(action_obj) = node_dict.get(b"A") {
+        let action_obj = match action_obj {
+            lopdf::Object::Reference(id) => match doc.get_object(*id) {
+                Ok(obj) => obj,
+                Err(_) => return (None, None),
+            },
+            other => other,
+        };
+        if let Ok(action_dict) = action_obj.as_dict() {
+            if let Ok(lopdf::Object::Name(action_type)) = action_dict.get(b"S") {
+                if String::from_utf8_lossy(action_type) == "GoTo" {
+                    if let Ok(dest_obj) = action_dict.get(b"D") {
+                        if let Some(result) = resolve_dest_to_page(doc, dest_obj, pages_map) {
+                            return result;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (None, None)
+}
+
+/// Resolve a destination object to (page_number, dest_top).
+///
+/// Handles explicit destination arrays `[page_ref, /type, ...]` and named destinations.
+fn resolve_dest_to_page(
+    doc: &lopdf::Document,
+    dest_obj: &lopdf::Object,
+    pages_map: &std::collections::BTreeMap<u32, lopdf::ObjectId>,
+) -> Option<(Option<usize>, Option<f64>)> {
+    let dest_obj = match dest_obj {
+        lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+        other => other,
+    };
+
+    match dest_obj {
+        // Explicit destination array: [page_ref, /type, ...]
+        lopdf::Object::Array(arr) => {
+            if arr.is_empty() {
+                return None;
+            }
+            // First element is a page reference
+            if let lopdf::Object::Reference(page_ref) = &arr[0] {
+                // Resolve to 0-indexed page number
+                let page_number = pages_map.iter().find_map(|(&page_num, &page_id)| {
+                    if page_id == *page_ref {
+                        Some((page_num - 1) as usize) // lopdf pages are 1-indexed
+                    } else {
+                        None
+                    }
+                });
+
+                // Try to extract dest_top from /XYZ or /FitH or /FitBH destination types
+                let dest_top = extract_dest_top(arr);
+
+                return Some((page_number, dest_top));
+            }
+            None
+        }
+        // Named destination (string) — look up in /Names or /Dests
+        lopdf::Object::String(bytes, _) => {
+            let name = if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
+                let chars: Vec<u16> = bytes[2..]
+                    .chunks(2)
+                    .filter_map(|c| {
+                        if c.len() == 2 {
+                            Some(u16::from_be_bytes([c[0], c[1]]))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                String::from_utf16(&chars).ok()?
+            } else {
+                match std::str::from_utf8(bytes) {
+                    Ok(s) => s.to_string(),
+                    Err(_) => bytes.iter().map(|&b| b as char).collect(),
+                }
+            };
+            resolve_named_dest(doc, &name, pages_map)
+        }
+        // Named destination (name)
+        lopdf::Object::Name(name) => {
+            let name_str = String::from_utf8_lossy(name);
+            resolve_named_dest(doc, &name_str, pages_map)
+        }
+        _ => None,
+    }
+}
+
+/// Extract the dest_top (y-coordinate) from a destination array.
+///
+/// Supports /XYZ (index 3), /FitH (index 2), /FitBH (index 2).
+fn extract_dest_top(arr: &[lopdf::Object]) -> Option<f64> {
+    if arr.len() < 2 {
+        return None;
+    }
+    // Second element is the destination type
+    if let lopdf::Object::Name(dest_type) = &arr[1] {
+        let type_str = String::from_utf8_lossy(dest_type);
+        match type_str.as_ref() {
+            "XYZ" => {
+                // [page, /XYZ, left, top, zoom]
+                if arr.len() >= 4 {
+                    return obj_to_f64(&arr[3]);
+                }
+            }
+            "FitH" | "FitBH" => {
+                // [page, /FitH, top] or [page, /FitBH, top]
+                if arr.len() >= 3 {
+                    return obj_to_f64(&arr[2]);
+                }
+            }
+            _ => {} // /Fit, /FitV, /FitR, /FitB — no meaningful top
+        }
+    }
+    None
+}
+
+/// Convert a lopdf Object to f64 (handles Integer, Real, and Null).
+fn obj_to_f64(obj: &lopdf::Object) -> Option<f64> {
+    match obj {
+        lopdf::Object::Integer(i) => Some(*i as f64),
+        lopdf::Object::Real(f) => Some((*f).into()),
+        lopdf::Object::Null => None, // null means "unchanged" in PDF spec
+        _ => None,
+    }
+}
+
+/// Resolve a named destination to (page_number, dest_top).
+///
+/// Looks up the name in the catalog's /Names → /Dests name tree,
+/// or in the catalog's /Dests dictionary.
+fn resolve_named_dest(
+    doc: &lopdf::Document,
+    name: &str,
+    pages_map: &std::collections::BTreeMap<u32, lopdf::ObjectId>,
+) -> Option<(Option<usize>, Option<f64>)> {
+    // Get catalog
+    let catalog_ref = doc.trailer.get(b"Root").ok()?;
+    let catalog = match catalog_ref {
+        lopdf::Object::Reference(id) => doc.get_object(*id).ok()?.as_dict().ok()?,
+        lopdf::Object::Dictionary(dict) => dict,
+        _ => return None,
+    };
+
+    // Try /Names → /Dests name tree first
+    if let Ok(names_obj) = catalog.get(b"Names") {
+        let names_obj = match names_obj {
+            lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+            other => other,
+        };
+        if let Ok(names_dict) = names_obj.as_dict() {
+            if let Ok(dests_obj) = names_dict.get(b"Dests") {
+                let dests_obj = match dests_obj {
+                    lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+                    other => other,
+                };
+                if let Ok(dests_dict) = dests_obj.as_dict() {
+                    if let Some(result) = lookup_name_tree(doc, dests_dict, name, pages_map) {
+                        return Some(result);
+                    }
+                }
+            }
+        }
+    }
+
+    // Try /Dests dictionary (older PDF spec)
+    if let Ok(dests_obj) = catalog.get(b"Dests") {
+        let dests_obj = match dests_obj {
+            lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+            other => other,
+        };
+        if let Ok(dests_dict) = dests_obj.as_dict() {
+            if let Ok(dest_obj) = dests_dict.get(name.as_bytes()) {
+                let dest_obj = match dest_obj {
+                    lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+                    other => other,
+                };
+                // Could be an array directly or a dict with /D key
+                match dest_obj {
+                    lopdf::Object::Array(arr) => {
+                        if let Some(result) =
+                            resolve_dest_to_page(doc, &lopdf::Object::Array(arr.clone()), pages_map)
+                        {
+                            return Some(result);
+                        }
+                    }
+                    lopdf::Object::Dictionary(d) => {
+                        if let Ok(d_dest) = d.get(b"D") {
+                            if let Some(result) = resolve_dest_to_page(doc, d_dest, pages_map) {
+                                return Some(result);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Look up a name in a PDF name tree (/Names array with key-value pairs).
+fn lookup_name_tree(
+    doc: &lopdf::Document,
+    tree_dict: &lopdf::Dictionary,
+    name: &str,
+    pages_map: &std::collections::BTreeMap<u32, lopdf::ObjectId>,
+) -> Option<(Option<usize>, Option<f64>)> {
+    // Check /Names array (leaf node)
+    if let Ok(names_arr_obj) = tree_dict.get(b"Names") {
+        let names_arr_obj = match names_arr_obj {
+            lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+            other => other,
+        };
+        if let Ok(names_arr) = names_arr_obj.as_array() {
+            // Names array is [key1, value1, key2, value2, ...]
+            let mut i = 0;
+            while i + 1 < names_arr.len() {
+                let key_obj = match &names_arr[i] {
+                    lopdf::Object::Reference(id) => match doc.get_object(*id) {
+                        Ok(obj) => obj.clone(),
+                        Err(_) => {
+                            i += 2;
+                            continue;
+                        }
+                    },
+                    other => other.clone(),
+                };
+                if let lopdf::Object::String(key_bytes, _) = &key_obj {
+                    let key_str = String::from_utf8_lossy(key_bytes);
+                    if key_str == name {
+                        let value = &names_arr[i + 1];
+                        let value = match value {
+                            lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+                            other => other,
+                        };
+                        // Value can be an array (destination) or dict with /D
+                        match value {
+                            lopdf::Object::Array(arr) => {
+                                return resolve_dest_to_page(
+                                    doc,
+                                    &lopdf::Object::Array(arr.clone()),
+                                    pages_map,
+                                );
+                            }
+                            lopdf::Object::Dictionary(d) => {
+                                if let Ok(d_dest) = d.get(b"D") {
+                                    return resolve_dest_to_page(doc, d_dest, pages_map);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                i += 2;
+            }
+        }
+    }
+
+    // Check /Kids array (intermediate nodes)
+    if let Ok(kids_obj) = tree_dict.get(b"Kids") {
+        let kids_obj = match kids_obj {
+            lopdf::Object::Reference(id) => doc.get_object(*id).ok()?,
+            other => other,
+        };
+        if let Ok(kids_arr) = kids_obj.as_array() {
+            for kid in kids_arr {
+                let kid_obj = match kid {
+                    lopdf::Object::Reference(id) => match doc.get_object(*id) {
+                        Ok(obj) => obj,
+                        Err(_) => continue,
+                    },
+                    other => other,
+                };
+                if let Ok(kid_dict) = kid_obj.as_dict() {
+                    if let Some(result) = lookup_name_tree(doc, kid_dict, name, pages_map) {
+                        return Some(result);
+                    }
+                }
+            }
+        }
+    }
+
+    None
 }
 
 /// Extract annotations from a page's /Annots array.

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -97,16 +97,16 @@ pub use cropped_page::CroppedPage;
 pub use page::Page;
 pub use pdf::{PagesIter, Pdf};
 pub use pdfplumber_core::{
-    Annotation, AnnotationType, BBox, Cell, Char, Color, Ctm, Curve, DashPattern, DocumentMetadata,
-    Edge, EdgeSource, EncodingResolver, ExplicitLines, ExtGState, ExtractOptions, ExtractResult,
-    ExtractWarning, FillRule, FontEncoding, GraphicsState, Hyperlink, Image, ImageMetadata,
-    Intersection, Line, LineOrientation, Orientation, PaintedPath, Path, PathBuilder, PathSegment,
-    PdfError, Point, Rect, StandardEncoding, Strategy, Table, TableFinder, TableSettings,
-    TextBlock, TextDirection, TextLine, TextOptions, Word, WordExtractor, WordOptions,
-    blocks_to_text, cells_to_tables, cluster_lines_into_blocks, cluster_words_into_lines,
-    derive_edges, edge_from_curve, edge_from_line, edges_from_rect, edges_to_intersections,
-    explicit_lines_to_edges, extract_shapes, extract_text_for_cells, image_from_ctm,
-    intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
+    Annotation, AnnotationType, BBox, Bookmark, Cell, Char, Color, Ctm, Curve, DashPattern,
+    DocumentMetadata, Edge, EdgeSource, EncodingResolver, ExplicitLines, ExtGState, ExtractOptions,
+    ExtractResult, ExtractWarning, FillRule, FontEncoding, GraphicsState, Hyperlink, Image,
+    ImageMetadata, Intersection, Line, LineOrientation, Orientation, PaintedPath, Path,
+    PathBuilder, PathSegment, PdfError, Point, Rect, StandardEncoding, Strategy, Table,
+    TableFinder, TableSettings, TextBlock, TextDirection, TextLine, TextOptions, Word,
+    WordExtractor, WordOptions, blocks_to_text, cells_to_tables, cluster_lines_into_blocks,
+    cluster_words_into_lines, derive_edges, edge_from_curve, edge_from_line, edges_from_rect,
+    edges_to_intersections, explicit_lines_to_edges, extract_shapes, extract_text_for_cells,
+    image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
     sort_blocks_reading_order, split_lines_at_columns, words_to_edges_stream, words_to_text,
 };
 pub use pdfplumber_parse::{

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -96,7 +96,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": "Parsing is in pdfplumber-parse, Bookmark type in pdfplumber-core, API in pdfplumber facade. Reference: PyMuPDF Document.get_toc()."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -9,6 +9,7 @@
 - **CLI box display**: MediaBox always shown; optional boxes only shown when present. JSON uses conditional insertion (`page_json["key"] = val`). Text uses `if let Some(ref b) = ...`.
 - **Hyperlink pattern**: Hyperlinks follow: add `page_hyperlinks()` trait method → implement in LopdfBackend filtering for Link annotations and resolving /A (URI, GoTo) or /Dest → add `Vec<Hyperlink>` field to Page → pass through `from_extraction()`. Skip links without resolvable URIs.
 - **CLI subcommand pattern**: New CLI commands: add variant to `Commands` enum in cli.rs → create `<name>_cmd.rs` with `run()`, `write_text()`, `write_json()`, `write_csv()` → wire up in main.rs match. Each output format follows the same structure (header + per-page iteration).
+- **Bookmark/outline pattern**: Document-level outlines follow: add `document_bookmarks()` to PdfBackend trait → implement in LopdfBackend walking outline tree via /First, /Next sibling links → cache in Pdf struct on open → expose via `Pdf::bookmarks()`. Resolve destinations using `doc.get_pages()` (1-indexed page map). Handle circular references with visited set + max depth limit.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
@@ -99,4 +100,31 @@ Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
   - /Dest on the annotation is a direct destination (no action dict)
   - Annotations without resolvable actions/dests are skipped (graceful handling)
   - `page_hyperlinks()` follows the same backend trait pattern as `page_annotations()`
+---
+
+## 2026-02-28 - US-062
+- Implemented bookmark / outline / table of contents extraction
+- Files changed:
+  - `crates/pdfplumber-core/src/bookmark.rs` (NEW) — Bookmark struct
+  - `crates/pdfplumber-core/src/lib.rs` — Added bookmark module and export
+  - `crates/pdfplumber-parse/src/backend.rs` — Added `document_bookmarks()` to PdfBackend trait + mock
+  - `crates/pdfplumber-parse/src/lopdf_backend.rs` — Implemented outline tree walking with destination resolution
+  - `crates/pdfplumber/src/pdf.rs` — Added bookmarks field to Pdf struct, caches on open, `bookmarks()` accessor
+  - `crates/pdfplumber/src/lib.rs` — Re-exported Bookmark
+  - `crates/pdfplumber/tests/pdf_integration.rs` — 3 integration tests (multi-level, no outlines, GoTo action)
+  - `crates/pdfplumber-cli/src/cli.rs` — Added Bookmarks subcommand with --format json/text
+  - `crates/pdfplumber-cli/src/bookmarks_cmd.rs` (NEW) — Bookmarks CLI command
+  - `crates/pdfplumber-cli/src/main.rs` — Wired up bookmarks command
+  - `crates/pdfplumber-cli/tests/bookmarks_cmd.rs` (NEW) — 3 CLI tests
+- Dependencies added: None
+- **Learnings for future iterations:**
+  - Outlines are document-level (not page-level), accessed via catalog /Outlines
+  - Outline tree uses /First (first child), /Next (next sibling) links — walk iteratively with visited set
+  - lopdf `doc.get_pages()` returns BTreeMap<u32, ObjectId> with 1-indexed page numbers
+  - Destinations can be explicit arrays `[page_ref, /type, ...]` or named destinations
+  - /XYZ destination type has `[page, /XYZ, left, top, zoom]` — top is at index 3
+  - /FitH and /FitBH have `[page, /type, top]` — top is at index 2
+  - Named destinations are looked up in catalog /Names → /Dests name tree or catalog /Dests dictionary
+  - Circular reference protection: visited set + max_depth (64) + max_siblings (10,000) limits
+  - Bookmarks follow the metadata pattern: document-level, cached on open, exposed via accessor
 ---


### PR DESCRIPTION
## Summary

- Add `Bookmark` struct in `pdfplumber-core` for representing document outline entries
- Implement outline tree walking in `LopdfBackend` with destination resolution (explicit destinations, GoTo actions, named destinations)
- Add `Pdf::bookmarks()` API for accessing flattened bookmark list with title, level, page number, and dest_top
- Add `bookmarks` CLI subcommand with `--format text/json` output
- Handle circular references with visited set, max depth (64), and max siblings (10,000) limits
- Support /XYZ, /FitH, /FitBH destination types for dest_top extraction

## Test plan

- [x] Unit tests for `Bookmark` struct (core crate)
- [x] Integration test: multi-level bookmarks with page destinations
- [x] Integration test: PDF with no outlines returns empty
- [x] Integration test: GoTo action destination resolution with FitH
- [x] CLI test: text format output shows bookmark titles
- [x] CLI test: JSON format output shows structured entries
- [x] CLI test: no bookmarks shows "No bookmarks found."
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)