### PR TITLE
feat: US-064 - Duplicate character deduplication

### DIFF
--- a/crates/pdfplumber-core/src/dedupe.rs
+++ b/crates/pdfplumber-core/src/dedupe.rs
@@ -1,0 +1,315 @@
+//! Duplicate character deduplication.
+//!
+//! Removes duplicate overlapping characters that some PDF generators output
+//! (for bold effect or due to bugs). Reference: pdfplumber(Py) `Page.dedupe_chars()`.
+
+use crate::text::Char;
+
+/// Options for duplicate character detection and removal.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DedupeOptions {
+    /// Maximum distance (in points) between character positions to consider
+    /// them as duplicates. Default: `1.0`.
+    pub tolerance: f64,
+    /// Additional character attributes that must match for two characters to be
+    /// considered duplicates. Default: `["fontname", "size"]`.
+    ///
+    /// Supported attribute names: `"fontname"`, `"size"`, `"upright"`,
+    /// `"stroking_color"`, `"non_stroking_color"`.
+    pub extra_attrs: Vec<String>,
+}
+
+impl Default for DedupeOptions {
+    fn default() -> Self {
+        Self {
+            tolerance: 1.0,
+            extra_attrs: vec!["fontname".to_string(), "size".to_string()],
+        }
+    }
+}
+
+/// Returns whether two characters match on the given attribute name.
+fn attrs_match(a: &Char, b: &Char, attr: &str) -> bool {
+    match attr {
+        "fontname" => a.fontname == b.fontname,
+        "size" => (a.size - b.size).abs() < f64::EPSILON,
+        "upright" => a.upright == b.upright,
+        "stroking_color" => a.stroking_color == b.stroking_color,
+        "non_stroking_color" => a.non_stroking_color == b.non_stroking_color,
+        _ => true, // Unknown attributes are ignored (treated as matching)
+    }
+}
+
+/// Returns whether two characters are duplicates according to the given options.
+///
+/// Two characters are considered duplicates if:
+/// 1. They have the same text content
+/// 2. Their positions (x0, top) are within the tolerance
+/// 3. All specified extra attributes match
+fn is_duplicate(a: &Char, b: &Char, options: &DedupeOptions) -> bool {
+    // Must have the same text
+    if a.text != b.text {
+        return false;
+    }
+
+    // Positions must be within tolerance
+    let dx = (a.bbox.x0 - b.bbox.x0).abs();
+    let dy = (a.bbox.top - b.bbox.top).abs();
+    if dx > options.tolerance || dy > options.tolerance {
+        return false;
+    }
+
+    // All extra attributes must match
+    options
+        .extra_attrs
+        .iter()
+        .all(|attr| attrs_match(a, b, attr))
+}
+
+/// Remove duplicate overlapping characters from a slice.
+///
+/// Iterates through characters in order, keeping the first occurrence and
+/// discarding subsequent duplicates. Two characters are duplicates if their
+/// positions overlap within `tolerance` and the specified `extra_attrs` match.
+///
+/// The original slice is not modified; a new `Vec<Char>` is returned.
+pub fn dedupe_chars(chars: &[Char], options: &DedupeOptions) -> Vec<Char> {
+    let mut kept: Vec<Char> = Vec::with_capacity(chars.len());
+
+    for ch in chars {
+        let dominated = kept.iter().any(|k| is_duplicate(k, ch, options));
+        if !dominated {
+            kept.push(ch.clone());
+        }
+    }
+
+    kept
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geometry::BBox;
+    use crate::painting::Color;
+    use crate::text::TextDirection;
+
+    fn make_char(text: &str, x0: f64, top: f64, x1: f64, bottom: f64) -> Char {
+        Char {
+            text: text.to_string(),
+            bbox: BBox::new(x0, top, x1, bottom),
+            fontname: "Helvetica".to_string(),
+            size: 12.0,
+            doctop: top,
+            upright: true,
+            direction: TextDirection::Ltr,
+            stroking_color: None,
+            non_stroking_color: None,
+            ctm: [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            char_code: 0,
+        }
+    }
+
+    fn make_char_with_font(text: &str, x0: f64, top: f64, fontname: &str, size: f64) -> Char {
+        Char {
+            text: text.to_string(),
+            bbox: BBox::new(x0, top, x0 + 10.0, top + 12.0),
+            fontname: fontname.to_string(),
+            size,
+            doctop: top,
+            upright: true,
+            direction: TextDirection::Ltr,
+            stroking_color: None,
+            non_stroking_color: None,
+            ctm: [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            char_code: 0,
+        }
+    }
+
+    #[test]
+    fn test_overlapping_identical_chars_deduped() {
+        // Two "A" chars at nearly the same position — should be deduped to one
+        let chars = vec![
+            make_char("A", 10.0, 20.0, 20.0, 32.0),
+            make_char("A", 10.5, 20.3, 20.5, 32.3), // within tolerance=1.0
+        ];
+
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].text, "A");
+        // First occurrence is kept
+        assert!((result[0].bbox.x0 - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_non_overlapping_chars_preserved() {
+        // Two "A" chars at different positions — should NOT be deduped
+        let chars = vec![
+            make_char("A", 10.0, 20.0, 20.0, 32.0),
+            make_char("A", 50.0, 20.0, 60.0, 32.0), // far apart
+        ];
+
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_different_text_not_deduped() {
+        // "A" and "B" at the same position — should NOT be deduped
+        let chars = vec![
+            make_char("A", 10.0, 20.0, 20.0, 32.0),
+            make_char("B", 10.0, 20.0, 20.0, 32.0),
+        ];
+
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_different_font_not_deduped() {
+        // Same text, same position, but different font — should NOT be deduped
+        let chars = vec![
+            make_char_with_font("A", 10.0, 20.0, "Helvetica", 12.0),
+            make_char_with_font("A", 10.0, 20.0, "Times-Roman", 12.0),
+        ];
+
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_different_size_not_deduped() {
+        // Same text, same position, same font, different size — should NOT be deduped
+        let chars = vec![
+            make_char_with_font("A", 10.0, 20.0, "Helvetica", 12.0),
+            make_char_with_font("A", 10.0, 20.0, "Helvetica", 14.0),
+        ];
+
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_custom_tolerance() {
+        // Two chars 2.5 points apart — not deduped with default tolerance=1.0
+        // but deduped with tolerance=3.0
+        let chars = vec![
+            make_char("A", 10.0, 20.0, 20.0, 32.0),
+            make_char("A", 12.5, 20.0, 22.5, 32.0),
+        ];
+
+        let default_result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(
+            default_result.len(),
+            2,
+            "Default tolerance should not merge these"
+        );
+
+        let wide_result = dedupe_chars(
+            &chars,
+            &DedupeOptions {
+                tolerance: 3.0,
+                ..DedupeOptions::default()
+            },
+        );
+        assert_eq!(wide_result.len(), 1, "Wide tolerance should merge these");
+    }
+
+    #[test]
+    fn test_empty_extra_attrs() {
+        // With no extra_attrs, only text + position matter
+        // Different font chars at same position should be deduped
+        let chars = vec![
+            make_char_with_font("A", 10.0, 20.0, "Helvetica", 12.0),
+            make_char_with_font("A", 10.0, 20.0, "Times-Roman", 14.0),
+        ];
+
+        let result = dedupe_chars(
+            &chars,
+            &DedupeOptions {
+                tolerance: 1.0,
+                extra_attrs: vec![],
+            },
+        );
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_duplicates_keep_first() {
+        // Three identical chars — should keep only the first
+        let chars = vec![
+            make_char("A", 10.0, 20.0, 20.0, 32.0),
+            make_char("A", 10.2, 20.1, 20.2, 32.1),
+            make_char("A", 10.4, 20.2, 20.4, 32.2),
+        ];
+
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 1);
+        assert!((result[0].bbox.x0 - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_mixed_chars_only_duplicates_removed() {
+        // "H" "e" "l" "l" "o" with "H" duplicated
+        let chars = vec![
+            make_char("H", 10.0, 20.0, 20.0, 32.0),
+            make_char("H", 10.1, 20.0, 20.1, 32.0), // duplicate of first H
+            make_char("e", 20.0, 20.0, 30.0, 32.0),
+            make_char("l", 30.0, 20.0, 40.0, 32.0),
+            make_char("l", 40.0, 20.0, 50.0, 32.0), // NOT a dup (different position)
+            make_char("o", 50.0, 20.0, 60.0, 32.0),
+        ];
+
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 5);
+        let texts: Vec<&str> = result.iter().map(|c| c.text.as_str()).collect();
+        assert_eq!(texts, vec!["H", "e", "l", "l", "o"]);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let result = dedupe_chars(&[], &DedupeOptions::default());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_single_char() {
+        let chars = vec![make_char("A", 10.0, 20.0, 20.0, 32.0)];
+        let result = dedupe_chars(&chars, &DedupeOptions::default());
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_color_as_extra_attr() {
+        // Two chars at same position, same text, same font, but different fill color
+        let mut c1 = make_char("A", 10.0, 20.0, 20.0, 32.0);
+        c1.non_stroking_color = Some(Color::Rgb(1.0, 0.0, 0.0));
+        let mut c2 = make_char("A", 10.0, 20.0, 20.0, 32.0);
+        c2.non_stroking_color = Some(Color::Rgb(0.0, 0.0, 1.0));
+
+        // With default extra_attrs (fontname, size) → deduped (colors not checked)
+        let result = dedupe_chars(&[c1.clone(), c2.clone()], &DedupeOptions::default());
+        assert_eq!(result.len(), 1);
+
+        // With non_stroking_color in extra_attrs → not deduped
+        let result = dedupe_chars(
+            &[c1, c2],
+            &DedupeOptions {
+                tolerance: 1.0,
+                extra_attrs: vec![
+                    "fontname".to_string(),
+                    "size".to_string(),
+                    "non_stroking_color".to_string(),
+                ],
+            },
+        );
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_default_options() {
+        let opts = DedupeOptions::default();
+        assert!((opts.tolerance - 1.0).abs() < f64::EPSILON);
+        assert_eq!(opts.extra_attrs, vec!["fontname", "size"]);
+    }
+}

--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -27,6 +27,8 @@
 pub mod annotation;
 /// PDF bookmark / outline / table of contents types.
 pub mod bookmark;
+/// Duplicate character deduplication.
+pub mod dedupe;
 /// Edge derivation from geometric primitives for table detection.
 pub mod edges;
 /// Font encoding mapping (Standard, Windows, Mac, Custom).
@@ -60,6 +62,7 @@ pub mod words;
 
 pub use annotation::{Annotation, AnnotationType};
 pub use bookmark::Bookmark;
+pub use dedupe::{DedupeOptions, dedupe_chars};
 pub use edges::{Edge, EdgeSource, derive_edges, edge_from_curve, edge_from_line, edges_from_rect};
 pub use encoding::{EncodingResolver, FontEncoding, StandardEncoding};
 pub use error::{ExtractOptions, ExtractResult, ExtractWarning, PdfError};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -98,16 +98,17 @@ pub use page::Page;
 pub use pdf::{PagesIter, Pdf};
 pub use pdfplumber_core::{
     Annotation, AnnotationType, BBox, Bookmark, Cell, Char, Color, Ctm, Curve, DashPattern,
-    DocumentMetadata, Edge, EdgeSource, EncodingResolver, ExplicitLines, ExtGState, ExtractOptions,
-    ExtractResult, ExtractWarning, FillRule, FontEncoding, GraphicsState, Hyperlink, Image,
-    ImageMetadata, Intersection, Line, LineOrientation, Orientation, PaintedPath, Path,
-    PathBuilder, PathSegment, PdfError, Point, Rect, SearchMatch, SearchOptions, StandardEncoding,
-    Strategy, Table, TableFinder, TableSettings, TextBlock, TextDirection, TextLine, TextOptions,
-    Word, WordExtractor, WordOptions, blocks_to_text, cells_to_tables, cluster_lines_into_blocks,
-    cluster_words_into_lines, derive_edges, edge_from_curve, edge_from_line, edges_from_rect,
-    edges_to_intersections, explicit_lines_to_edges, extract_shapes, extract_text_for_cells,
-    image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
-    sort_blocks_reading_order, split_lines_at_columns, words_to_edges_stream, words_to_text,
+    DedupeOptions, DocumentMetadata, Edge, EdgeSource, EncodingResolver, ExplicitLines, ExtGState,
+    ExtractOptions, ExtractResult, ExtractWarning, FillRule, FontEncoding, GraphicsState,
+    Hyperlink, Image, ImageMetadata, Intersection, Line, LineOrientation, Orientation, PaintedPath,
+    Path, PathBuilder, PathSegment, PdfError, Point, Rect, SearchMatch, SearchOptions,
+    StandardEncoding, Strategy, Table, TableFinder, TableSettings, TextBlock, TextDirection,
+    TextLine, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text, cells_to_tables,
+    cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, edge_from_curve,
+    edge_from_line, edges_from_rect, edges_to_intersections, explicit_lines_to_edges,
+    extract_shapes, extract_text_for_cells, image_from_ctm, intersections_to_cells, is_cjk,
+    is_cjk_text, join_edge_group, snap_edges, sort_blocks_reading_order, split_lines_at_columns,
+    words_to_edges_stream, words_to_text,
 };
 pub use pdfplumber_parse::{
     self, CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, LopdfPage,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -135,7 +135,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 7,
-      "passes": false,
+      "passes": true,
       "notes": "Implement in pdfplumber-core as a character filter algorithm."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -11,6 +11,7 @@
 - **CLI subcommand pattern**: New CLI commands: add variant to `Commands` enum in cli.rs → create `<name>_cmd.rs` with `run()`, `write_text()`, `write_json()`, `write_csv()` → wire up in main.rs match. Each output format follows the same structure (header + per-page iteration).
 - **Bookmark/outline pattern**: Document-level outlines follow: add `document_bookmarks()` to PdfBackend trait → implement in LopdfBackend walking outline tree via /First, /Next sibling links → cache in Pdf struct on open → expose via `Pdf::bookmarks()`. Resolve destinations using `doc.get_pages()` (1-indexed page map). Handle circular references with visited set + max depth limit.
 - **Search pattern**: Text search follows: add types (SearchMatch, SearchOptions) + algorithm (search_chars) in pdfplumber-core/search.rs → add Page::search() delegating to search_chars → add Pdf::search_all() iterating pages. Algorithm: concatenate char texts, map byte offsets→char indices, run regex, compute union bbox from matched chars.
+- **Dedupe pattern**: Character deduplication follows: add DedupeOptions struct + dedupe_chars() algorithm in pdfplumber-core/dedupe.rs → add Page::dedupe_chars() and CroppedPage::dedupe_chars() returning CroppedPage with filtered chars. Algorithm: iterate chars, check each against kept list (same text, positions within tolerance, extra_attrs match), keep first occurrence. Uses from_page_data() helper to build CroppedPage without coordinate adjustment.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
@@ -153,4 +154,23 @@ Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
   - Invalid regex patterns return empty results (graceful degradation)
   - Page::search() delegates to search_chars() with the page's chars and page_number
   - Pdf::search_all() iterates all pages and collects matches
+---
+
+## 2026-02-28 - US-064
+- Implemented duplicate character deduplication
+- Files changed:
+  - `crates/pdfplumber-core/src/dedupe.rs` (NEW) — DedupeOptions struct, dedupe_chars() algorithm
+  - `crates/pdfplumber-core/src/lib.rs` — Added dedupe module and exports
+  - `crates/pdfplumber/src/page.rs` — Added Page::dedupe_chars() method
+  - `crates/pdfplumber/src/cropped_page.rs` — Added CroppedPage::dedupe_chars() method + from_page_data() helper
+  - `crates/pdfplumber/src/lib.rs` — Re-exported DedupeOptions
+  - `crates/pdfplumber/tests/pdf_integration.rs` — 3 integration tests (overlapping deduped, non-overlapping preserved, different font not deduped)
+- Dependencies added: None
+- **Learnings for future iterations:**
+  - Deduplication is a pure character filter — no backend trait changes needed
+  - The algorithm is O(n*k) where n=total chars, k=kept chars; fine for typical PDF pages
+  - CroppedPage can be constructed without coordinate adjustment via from_page_data() helper
+  - DedupeOptions uses Vec<String> for extra_attrs to match Python's flexible attribute matching
+  - Position comparison uses x0 and top within tolerance (not full bbox overlap)
+  - Different text content at same position is NOT deduped (e.g., overlapping "A" and "B")
 ---


### PR DESCRIPTION
## Summary
- Add `DedupeOptions` struct with configurable `tolerance` (default 1.0) and `extra_attrs` (default `["fontname", "size"]`)
- Implement `dedupe_chars()` algorithm in pdfplumber-core that removes duplicate overlapping characters
- Add `Page::dedupe_chars()` and `CroppedPage::dedupe_chars()` methods returning `CroppedPage` with duplicates removed
- Re-export `DedupeOptions` from the pdfplumber facade crate

## Test plan
- [x] 13 unit tests in pdfplumber-core: overlapping identical chars deduped, non-overlapping preserved, different text/font/size not deduped, custom tolerance, empty extra_attrs, multiple duplicates, mixed chars, empty input, single char, color attrs
- [x] 3 integration tests with real PDF parsing: overlapping identical chars deduped, non-overlapping preserved, different font not deduped (with empty extra_attrs override)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)