### PR TITLE
feat: US-066 - Custom object filtering - filter() method

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -46,6 +46,8 @@ pub mod images;
 pub mod layout;
 /// Document-level metadata types.
 pub mod metadata;
+/// PageObject enum for custom object filtering.
+pub mod page_object;
 /// Graphics state, colors, dash patterns, and painted paths.
 pub mod painting;
 /// PDF path construction (MoveTo, LineTo, CurveTo, ClosePath).
@@ -77,6 +79,7 @@ pub use layout::{
     cluster_words_into_lines, sort_blocks_reading_order, split_lines_at_columns, words_to_text,
 };
 pub use metadata::DocumentMetadata;
+pub use page_object::PageObject;
 pub use painting::{Color, DashPattern, ExtGState, FillRule, GraphicsState, PaintedPath};
 pub use path::{Path, PathBuilder, PathSegment};
 pub use search::{SearchMatch, SearchOptions, search_chars};

--- a/crates/pdfplumber-core/src/page_object.rs
+++ b/crates/pdfplumber-core/src/page_object.rs
@@ -1,0 +1,34 @@
+//! PageObject enum for custom filtering.
+//!
+//! [`PageObject`] wraps references to different page object types (characters,
+//! lines, rectangles, curves, images) so that a single predicate function can
+//! inspect any object on a page.
+
+use crate::{Char, Curve, Image, Line, Rect};
+
+/// An enum wrapping references to different page object types.
+///
+/// Used as the argument to filter predicates, allowing users to match on
+/// specific object types and inspect their properties.
+///
+/// # Example
+///
+/// ```ignore
+/// // Keep only characters with font "Helvetica" and all non-char objects
+/// page.filter(|obj| match obj {
+///     PageObject::Char(c) => c.fontname == "Helvetica",
+///     _ => true,
+/// });
+/// ```
+pub enum PageObject<'a> {
+    /// A character object.
+    Char(&'a Char),
+    /// A line object.
+    Line(&'a Line),
+    /// A rectangle object.
+    Rect(&'a Rect),
+    /// A curve object.
+    Curve(&'a Curve),
+    /// An image object.
+    Image(&'a Image),
+}

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -96,12 +96,19 @@ mod pdf;
 pub use cropped_page::CroppedPage;
 pub use page::Page;
 pub use pdf::{PagesIter, Pdf};
+
+/// A page view produced by [`Page::filter`] or [`CroppedPage::filter`].
+///
+/// `FilteredPage` is a type alias for [`CroppedPage`] — it supports all the
+/// same query methods (`chars()`, `extract_text()`, `find_tables()`, etc.)
+/// and can be filtered again for composable filtering chains.
+pub type FilteredPage = CroppedPage;
 pub use pdfplumber_core::{
     Annotation, AnnotationType, BBox, Bookmark, Cell, Char, Color, Ctm, Curve, DashPattern,
     DedupeOptions, DocumentMetadata, Edge, EdgeSource, EncodingResolver, ExplicitLines, ExtGState,
     ExtractOptions, ExtractResult, ExtractWarning, FillRule, FontEncoding, GraphicsState,
-    Hyperlink, Image, ImageMetadata, Intersection, Line, LineOrientation, Orientation, PaintedPath,
-    Path, PathBuilder, PathSegment, PdfError, Point, Rect, SearchMatch, SearchOptions,
+    Hyperlink, Image, ImageMetadata, Intersection, Line, LineOrientation, Orientation, PageObject,
+    PaintedPath, Path, PathBuilder, PathSegment, PdfError, Point, Rect, SearchMatch, SearchOptions,
     StandardEncoding, Strategy, Table, TableFinder, TableSettings, TextBlock, TextDirection,
     TextLine, TextOptions, UnicodeNorm, Word, WordExtractor, WordOptions, blocks_to_text,
     cells_to_tables, cluster_lines_into_blocks, cluster_words_into_lines, derive_edges,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -170,7 +170,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 9,
-      "passes": false,
+      "passes": true,
       "notes": "May require refactoring CroppedPage and FilteredPage to share a common trait or use a unified page view abstraction."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -13,6 +13,7 @@
 - **Search pattern**: Text search follows: add types (SearchMatch, SearchOptions) + algorithm (search_chars) in pdfplumber-core/search.rs → add Page::search() delegating to search_chars → add Pdf::search_all() iterating pages. Algorithm: concatenate char texts, map byte offsets→char indices, run regex, compute union bbox from matched chars.
 - **Dedupe pattern**: Character deduplication follows: add DedupeOptions struct + dedupe_chars() algorithm in pdfplumber-core/dedupe.rs → add Page::dedupe_chars() and CroppedPage::dedupe_chars() returning CroppedPage with filtered chars. Algorithm: iterate chars, check each against kept list (same text, positions within tolerance, extra_attrs match), keep first occurrence. Uses from_page_data() helper to build CroppedPage without coordinate adjustment.
 - **ExtractOptions pattern**: Document-level extraction settings go in ExtractOptions (set at Pdf::open() time, used during Pdf::page()). For text processing options (normalization, etc.), add field to ExtractOptions, apply in Pdf::page() after char creation. CLI: add separate clap ValueEnum arg type with conversion method, use open_pdf_with_norm() helper.
+- **Filter pattern**: Custom filtering follows: add PageObject enum in pdfplumber-core/page_object.rs → add Page::filter() and CroppedPage::filter() accepting Fn(&PageObject) -> bool → return CroppedPage with filtered objects (no coordinate adjustment). FilteredPage is a type alias for CroppedPage. Uses from_page_data() for Page, direct struct construction for CroppedPage.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
@@ -199,4 +200,22 @@ Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
   - CLI uses a separate UnicodeNormArg enum for clap ValueEnum, with to_unicode_norm() conversion method
   - open_pdf_with_norm() helper avoids modifying the existing open_pdf() signature
   - NFC composes decomposed chars (e + combining accent → é), NFKC additionally decomposes ligatures (ﬁ → fi) and fullwidth chars (Ａ → A)
+---
+
+## 2026-02-28 - US-066
+- Implemented custom object filtering with filter() method
+- Files changed:
+  - `crates/pdfplumber-core/src/page_object.rs` (NEW) — PageObject enum wrapping Char/Line/Rect/Curve/Image references
+  - `crates/pdfplumber-core/src/lib.rs` — Added page_object module and export
+  - `crates/pdfplumber/src/page.rs` — Added Page::filter() method
+  - `crates/pdfplumber/src/cropped_page.rs` — Added CroppedPage::filter() method for chaining
+  - `crates/pdfplumber/src/lib.rs` — Added FilteredPage type alias, re-exported PageObject
+  - `crates/pdfplumber/tests/pdf_integration.rs` — 6 integration tests (font name, size, position, chained, extract_text, find_tables)
+- Dependencies added: None
+- **Learnings for future iterations:**
+  - filter() is a pure object-level operation — no backend trait changes needed, no coordinate adjustment
+  - PageObject uses lifetime references (`PageObject<'a>`) for zero-copy predicate inspection
+  - FilteredPage = CroppedPage type alias gives users a meaningful name while reusing all CroppedPage functionality
+  - Chaining works naturally: Page::filter() returns CroppedPage, CroppedPage::filter() returns CroppedPage
+  - Non-stroking colors are not populated in simple test PDFs (content stream interpreter limitation) — use position/font/size for test assertions instead
 ---


### PR DESCRIPTION
## Summary
- Added `PageObject` enum in pdfplumber-core wrapping references to Char/Line/Rect/Curve/Image
- Added `Page::filter()` and `CroppedPage::filter()` methods accepting `Fn(&PageObject) -> bool` predicates
- Added `FilteredPage` type alias for `CroppedPage` — supports all query methods (chars, extract_text, find_tables, etc.)
- Composable: `page.filter(f1).filter(f2)` works for chaining multiple filters

## Test plan
- [x] Filter by font name — keeps only chars matching fontname, preserves non-char objects
- [x] Filter by size — keeps only chars exceeding size threshold
- [x] Filter by position — keeps chars within specified bbox region
- [x] Chained filters — two sequential filters compose correctly
- [x] extract_text() on filtered page returns correct text
- [x] find_tables() works on filtered page without errors
- [x] All 4 quality checks pass: fmt, clippy, test, check

🤖 Generated with [Claude Code](https://claude.com/claude-code)