### PR TITLE
feat: US-068 - Visual debugging - object overlay drawing

### DIFF
--- a/crates/pdfplumber-cli/src/cli.rs
+++ b/crates/pdfplumber-cli/src/cli.rs
@@ -169,6 +169,21 @@ pub enum Commands {
         format: TextFormat,
     },
 
+    /// Generate debug SVG with object overlays
+    Debug {
+        /// Path to the PDF file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Page range (e.g. '1,3-5'). Default: all pages
+        #[arg(long)]
+        pages: Option<String>,
+
+        /// Output SVG file path
+        #[arg(long, value_name = "FILE")]
+        output: PathBuf,
+    },
+
     /// Search for text patterns with position information
     Search {
         /// Path to the PDF file
@@ -729,6 +744,47 @@ mod tests {
                 assert!(matches!(unicode_norm, Some(UnicodeNormArg::Nfkd)));
             }
             _ => panic!("expected Words subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_debug_subcommand() {
+        let cli = Cli::parse_from(["pdfplumber", "debug", "test.pdf", "--output", "out.svg"]);
+        match cli.command {
+            Commands::Debug {
+                ref file,
+                ref pages,
+                ref output,
+            } => {
+                assert_eq!(file, &PathBuf::from("test.pdf"));
+                assert!(pages.is_none());
+                assert_eq!(output, &PathBuf::from("out.svg"));
+            }
+            _ => panic!("expected Debug subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_debug_with_pages() {
+        let cli = Cli::parse_from([
+            "pdfplumber",
+            "debug",
+            "test.pdf",
+            "--pages",
+            "1-3",
+            "--output",
+            "debug.svg",
+        ]);
+        match cli.command {
+            Commands::Debug {
+                ref pages,
+                ref output,
+                ..
+            } => {
+                assert_eq!(pages.as_deref(), Some("1-3"));
+                assert_eq!(output, &PathBuf::from("debug.svg"));
+            }
+            _ => panic!("expected Debug subcommand"),
         }
     }
 

--- a/crates/pdfplumber-cli/src/debug_cmd.rs
+++ b/crates/pdfplumber-cli/src/debug_cmd.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use std::path::Path;
+
+use pdfplumber::{DrawStyle, SvgOptions, SvgRenderer, TableSettings};
+
+use crate::shared::{open_pdf, resolve_pages};
+
+pub fn run(file: &Path, pages: Option<&str>, output: &Path) -> Result<(), i32> {
+    let pdf = open_pdf(file)?;
+    let page_indices = resolve_pages(pages, pdf.page_count())?;
+
+    // Generate SVG for each page; if multiple pages, append page number to filename
+    let multi_page = page_indices.len() > 1;
+    let stem = output
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("debug");
+    let ext = output.extension().and_then(|s| s.to_str()).unwrap_or("svg");
+    let parent = output.parent().unwrap_or(Path::new("."));
+
+    for &idx in &page_indices {
+        let page = pdf.page(idx).map_err(|e| {
+            eprintln!("Error reading page {}: {e}", idx + 1);
+            1
+        })?;
+
+        let mut renderer = SvgRenderer::new(page.width(), page.height());
+
+        // Draw all extracted objects with default styles
+        renderer.draw_chars(page.chars(), &DrawStyle::chars_default());
+        renderer.draw_lines(page.lines(), &DrawStyle::lines_default());
+        renderer.draw_rects(page.rects(), &DrawStyle::rects_default());
+
+        // Draw edges
+        let edges = page.edges();
+        renderer.draw_edges(&edges, &DrawStyle::edges_default());
+
+        // Draw tables
+        let tables = page.find_tables(&TableSettings::default());
+        renderer.draw_tables(&tables, &DrawStyle::tables_default());
+
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        let out_path = if multi_page {
+            parent.join(format!("{stem}_page{}.{ext}", idx + 1))
+        } else {
+            output.to_path_buf()
+        };
+
+        fs::write(&out_path, &svg).map_err(|e| {
+            eprintln!("Error writing {}: {e}", out_path.display());
+            1
+        })?;
+
+        eprintln!("Wrote {}", out_path.display());
+    }
+
+    Ok(())
+}

--- a/crates/pdfplumber-cli/src/main.rs
+++ b/crates/pdfplumber-cli/src/main.rs
@@ -2,6 +2,7 @@ mod annots_cmd;
 mod bookmarks_cmd;
 mod chars_cmd;
 mod cli;
+mod debug_cmd;
 mod info_cmd;
 mod links_cmd;
 mod page_range;
@@ -93,6 +94,11 @@ fn main() {
             ref file,
             ref format,
         } => bookmarks_cmd::run(file, format),
+        cli::Commands::Debug {
+            ref file,
+            ref pages,
+            ref output,
+        } => debug_cmd::run(file, pages.as_deref(), output),
         cli::Commands::Search {
             ref file,
             ref pattern,

--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -86,7 +86,7 @@ pub use painting::{Color, DashPattern, ExtGState, FillRule, GraphicsState, Paint
 pub use path::{Path, PathBuilder, PathSegment};
 pub use search::{SearchMatch, SearchOptions, search_chars};
 pub use shapes::{Curve, Line, LineOrientation, Rect, extract_shapes};
-pub use svg::{SvgOptions, SvgRenderer};
+pub use svg::{DrawStyle, SvgOptions, SvgRenderer};
 pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableSettings,
     cells_to_tables, edges_to_intersections, explicit_lines_to_edges, extract_text_for_cells,

--- a/crates/pdfplumber-core/src/svg.rs
+++ b/crates/pdfplumber-core/src/svg.rs
@@ -1,10 +1,110 @@
 //! SVG rendering for visual debugging of PDF pages.
 //!
-//! Generates SVG representations of PDF pages showing page boundaries
-//! and coordinate system. This is the foundation for the visual debugging
-//! system — Python pdfplumber's most unique feature.
+//! Generates SVG representations of PDF pages showing page boundaries,
+//! coordinate system, and overlaid extracted objects (chars, lines, rects,
+//! edges, tables). This is pdfplumber's visual debugging system — Python
+//! pdfplumber's most unique feature.
 
+use crate::edges::Edge;
 use crate::geometry::BBox;
+use crate::shapes::{Line, Rect};
+use crate::table::Table;
+use crate::text::Char;
+
+/// Style options for drawing overlays on the SVG page.
+#[derive(Debug, Clone)]
+pub struct DrawStyle {
+    /// Fill color (CSS color string). `None` means no fill.
+    pub fill: Option<String>,
+    /// Stroke color (CSS color string). `None` means no stroke.
+    pub stroke: Option<String>,
+    /// Stroke width in points.
+    pub stroke_width: f64,
+    /// Opacity (0.0 = fully transparent, 1.0 = fully opaque).
+    pub opacity: f64,
+}
+
+impl Default for DrawStyle {
+    fn default() -> Self {
+        Self {
+            fill: None,
+            stroke: Some("black".to_string()),
+            stroke_width: 0.5,
+            opacity: 1.0,
+        }
+    }
+}
+
+impl DrawStyle {
+    /// Default style for character bounding boxes (blue outline).
+    pub fn chars_default() -> Self {
+        Self {
+            fill: None,
+            stroke: Some("blue".to_string()),
+            stroke_width: 0.3,
+            opacity: 0.7,
+        }
+    }
+
+    /// Default style for lines (red).
+    pub fn lines_default() -> Self {
+        Self {
+            fill: None,
+            stroke: Some("red".to_string()),
+            stroke_width: 1.0,
+            opacity: 0.8,
+        }
+    }
+
+    /// Default style for rectangles (green outline).
+    pub fn rects_default() -> Self {
+        Self {
+            fill: None,
+            stroke: Some("green".to_string()),
+            stroke_width: 0.5,
+            opacity: 0.8,
+        }
+    }
+
+    /// Default style for edges (orange).
+    pub fn edges_default() -> Self {
+        Self {
+            fill: None,
+            stroke: Some("orange".to_string()),
+            stroke_width: 0.5,
+            opacity: 0.8,
+        }
+    }
+
+    /// Default style for table cell boundaries (lightblue fill).
+    pub fn tables_default() -> Self {
+        Self {
+            fill: Some("lightblue".to_string()),
+            stroke: Some("steelblue".to_string()),
+            stroke_width: 0.5,
+            opacity: 0.3,
+        }
+    }
+
+    /// Build the SVG style attribute string.
+    fn to_svg_style(&self) -> String {
+        let mut parts = Vec::new();
+        match &self.fill {
+            Some(color) => parts.push(format!("fill:{color}")),
+            None => parts.push("fill:none".to_string()),
+        }
+        if let Some(color) = &self.stroke {
+            parts.push(format!("stroke:{color}"));
+            parts.push(format!("stroke-width:{}", self.stroke_width));
+        } else {
+            parts.push("stroke:none".to_string());
+        }
+        if (self.opacity - 1.0).abs() > f64::EPSILON {
+            parts.push(format!("opacity:{}", self.opacity));
+        }
+        parts.join(";")
+    }
+}
 
 /// Options for SVG generation.
 #[derive(Debug, Clone)]
@@ -31,6 +131,9 @@ impl Default for SvgOptions {
 ///
 /// `SvgRenderer` takes page dimensions and produces valid SVG 1.1 markup.
 /// The SVG coordinate system matches pdfplumber's top-left origin system.
+///
+/// Use the `draw_*` methods to add overlay elements, then call `to_svg()`
+/// to produce the final SVG string.
 pub struct SvgRenderer {
     /// Page width in points.
     page_width: f64,
@@ -38,6 +141,8 @@ pub struct SvgRenderer {
     page_height: f64,
     /// Bounding box of the page.
     page_bbox: BBox,
+    /// Accumulated SVG overlay elements.
+    elements: Vec<String>,
 }
 
 impl SvgRenderer {
@@ -48,6 +153,74 @@ impl SvgRenderer {
             page_width,
             page_height,
             page_bbox,
+            elements: Vec::new(),
+        }
+    }
+
+    /// Draw character bounding boxes onto the SVG.
+    pub fn draw_chars(&mut self, chars: &[Char], style: &DrawStyle) {
+        let style_attr = style.to_svg_style();
+        for ch in chars {
+            self.elements.push(format!(
+                "  <rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" style=\"{style_attr}\"/>\n",
+                ch.bbox.x0,
+                ch.bbox.top,
+                ch.bbox.width(),
+                ch.bbox.height(),
+            ));
+        }
+    }
+
+    /// Draw rectangle outlines/fills onto the SVG.
+    pub fn draw_rects(&mut self, rects: &[Rect], style: &DrawStyle) {
+        let style_attr = style.to_svg_style();
+        for r in rects {
+            self.elements.push(format!(
+                "  <rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" style=\"{style_attr}\"/>\n",
+                r.x0,
+                r.top,
+                r.x1 - r.x0,
+                r.bottom - r.top,
+            ));
+        }
+    }
+
+    /// Draw line segments onto the SVG.
+    pub fn draw_lines(&mut self, lines: &[Line], style: &DrawStyle) {
+        let style_attr = style.to_svg_style();
+        for l in lines {
+            self.elements.push(format!(
+                "  <line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" style=\"{style_attr}\"/>\n",
+                l.x0, l.top, l.x1, l.bottom,
+            ));
+        }
+    }
+
+    /// Draw detected edges onto the SVG.
+    pub fn draw_edges(&mut self, edges: &[Edge], style: &DrawStyle) {
+        let style_attr = style.to_svg_style();
+        for e in edges {
+            self.elements.push(format!(
+                "  <line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" style=\"{style_attr}\"/>\n",
+                e.x0, e.top, e.x1, e.bottom,
+            ));
+        }
+    }
+
+    /// Draw table cell boundaries onto the SVG.
+    pub fn draw_tables(&mut self, tables: &[Table], style: &DrawStyle) {
+        let style_attr = style.to_svg_style();
+        for table in tables {
+            // Draw each cell
+            for cell in &table.cells {
+                self.elements.push(format!(
+                    "  <rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" style=\"{style_attr}\"/>\n",
+                    cell.bbox.x0,
+                    cell.bbox.top,
+                    cell.bbox.width(),
+                    cell.bbox.height(),
+                ));
+            }
         }
     }
 
@@ -56,6 +229,7 @@ impl SvgRenderer {
     /// The output is a complete, valid SVG 1.1 document including:
     /// - Proper `viewBox` matching page dimensions
     /// - Page boundary rectangle
+    /// - All overlay elements added via `draw_*` methods
     /// - SVG coordinate system matching top-left origin
     pub fn to_svg(&self, options: &SvgOptions) -> String {
         let view_width = self.page_width;
@@ -83,6 +257,11 @@ impl SvgRenderer {
             self.page_bbox.height(),
         ));
 
+        // Overlay elements
+        for element in &self.elements {
+            svg.push_str(element);
+        }
+
         // Close SVG
         svg.push_str("</svg>\n");
 
@@ -93,6 +272,13 @@ impl SvgRenderer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::edges::EdgeSource;
+    use crate::geometry::Orientation;
+    use crate::painting::Color;
+    use crate::table::Cell;
+    use crate::text::TextDirection;
+
+    // --- Existing US-067 tests ---
 
     #[test]
     fn test_svg_default_options() {
@@ -211,5 +397,324 @@ mod tests {
         assert!(svg.contains("viewBox=\"0 0 50 50\""));
         assert!(svg.contains("width=\"50\""));
         assert!(svg.contains("height=\"50\""));
+    }
+
+    // --- US-068 tests: DrawStyle ---
+
+    #[test]
+    fn test_draw_style_default() {
+        let style = DrawStyle::default();
+        assert!(style.fill.is_none());
+        assert_eq!(style.stroke.as_deref(), Some("black"));
+        assert!((style.stroke_width - 0.5).abs() < f64::EPSILON);
+        assert!((style.opacity - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_draw_style_chars_default() {
+        let style = DrawStyle::chars_default();
+        assert!(style.fill.is_none());
+        assert_eq!(style.stroke.as_deref(), Some("blue"));
+    }
+
+    #[test]
+    fn test_draw_style_lines_default() {
+        let style = DrawStyle::lines_default();
+        assert_eq!(style.stroke.as_deref(), Some("red"));
+    }
+
+    #[test]
+    fn test_draw_style_rects_default() {
+        let style = DrawStyle::rects_default();
+        assert_eq!(style.stroke.as_deref(), Some("green"));
+    }
+
+    #[test]
+    fn test_draw_style_tables_default() {
+        let style = DrawStyle::tables_default();
+        assert_eq!(style.fill.as_deref(), Some("lightblue"));
+    }
+
+    #[test]
+    fn test_draw_style_to_svg_style_full() {
+        let style = DrawStyle {
+            fill: Some("red".to_string()),
+            stroke: Some("blue".to_string()),
+            stroke_width: 2.0,
+            opacity: 0.5,
+        };
+        let s = style.to_svg_style();
+        assert!(s.contains("fill:red"));
+        assert!(s.contains("stroke:blue"));
+        assert!(s.contains("stroke-width:2"));
+        assert!(s.contains("opacity:0.5"));
+    }
+
+    #[test]
+    fn test_draw_style_to_svg_style_no_fill() {
+        let style = DrawStyle {
+            fill: None,
+            stroke: Some("black".to_string()),
+            stroke_width: 1.0,
+            opacity: 1.0,
+        };
+        let s = style.to_svg_style();
+        assert!(s.contains("fill:none"));
+        assert!(s.contains("stroke:black"));
+        // opacity=1.0 should be omitted
+        assert!(!s.contains("opacity"));
+    }
+
+    // --- US-068 tests: draw_chars ---
+
+    fn make_char(text: &str, x0: f64, top: f64, x1: f64, bottom: f64) -> Char {
+        Char {
+            text: text.to_string(),
+            bbox: BBox::new(x0, top, x1, bottom),
+            fontname: "Helvetica".to_string(),
+            size: 12.0,
+            doctop: top,
+            upright: true,
+            direction: TextDirection::Ltr,
+            stroking_color: None,
+            non_stroking_color: None,
+            ctm: [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            char_code: 0,
+        }
+    }
+
+    #[test]
+    fn test_draw_chars_adds_rect_elements() {
+        let mut renderer = SvgRenderer::new(200.0, 200.0);
+        let chars = vec![
+            make_char("A", 10.0, 20.0, 18.0, 32.0),
+            make_char("B", 20.0, 20.0, 28.0, 32.0),
+        ];
+        renderer.draw_chars(&chars, &DrawStyle::chars_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        // Should contain rect elements for each char (page boundary + 2 char rects)
+        let rect_count = svg.matches("<rect").count();
+        assert_eq!(rect_count, 3, "1 page boundary + 2 char bboxes");
+        assert!(svg.contains("stroke:blue"));
+    }
+
+    #[test]
+    fn test_draw_chars_correct_coordinates() {
+        let mut renderer = SvgRenderer::new(200.0, 200.0);
+        let chars = vec![make_char("X", 10.0, 20.0, 25.0, 35.0)];
+        renderer.draw_chars(&chars, &DrawStyle::chars_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        // Check the char rect has correct position
+        assert!(svg.contains("x=\"10\""));
+        assert!(svg.contains("y=\"20\""));
+        assert!(svg.contains("width=\"15\"")); // 25 - 10
+        assert!(svg.contains("height=\"15\"")); // 35 - 20
+    }
+
+    // --- US-068 tests: draw_rects ---
+
+    fn make_rect(x0: f64, top: f64, x1: f64, bottom: f64) -> Rect {
+        Rect {
+            x0,
+            top,
+            x1,
+            bottom,
+            line_width: 1.0,
+            stroke: true,
+            fill: false,
+            stroke_color: Color::Gray(0.0),
+            fill_color: Color::Gray(1.0),
+        }
+    }
+
+    #[test]
+    fn test_draw_rects_adds_rect_elements() {
+        let mut renderer = SvgRenderer::new(200.0, 200.0);
+        let rects = vec![make_rect(50.0, 50.0, 150.0, 100.0)];
+        renderer.draw_rects(&rects, &DrawStyle::rects_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        let rect_count = svg.matches("<rect").count();
+        assert_eq!(rect_count, 2, "1 page boundary + 1 rect overlay");
+        assert!(svg.contains("stroke:green"));
+    }
+
+    // --- US-068 tests: draw_lines ---
+
+    fn make_line(x0: f64, top: f64, x1: f64, bottom: f64) -> Line {
+        Line {
+            x0,
+            top,
+            x1,
+            bottom,
+            line_width: 1.0,
+            stroke_color: Color::Gray(0.0),
+            orientation: Orientation::Horizontal,
+        }
+    }
+
+    #[test]
+    fn test_draw_lines_adds_line_elements() {
+        let mut renderer = SvgRenderer::new(200.0, 200.0);
+        let lines = vec![
+            make_line(10.0, 50.0, 190.0, 50.0),
+            make_line(100.0, 10.0, 100.0, 190.0),
+        ];
+        renderer.draw_lines(&lines, &DrawStyle::lines_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        let line_count = svg.matches("<line").count();
+        assert_eq!(line_count, 2);
+        assert!(svg.contains("stroke:red"));
+    }
+
+    #[test]
+    fn test_draw_lines_correct_coordinates() {
+        let mut renderer = SvgRenderer::new(200.0, 200.0);
+        let lines = vec![make_line(10.0, 50.0, 190.0, 50.0)];
+        renderer.draw_lines(&lines, &DrawStyle::lines_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        assert!(svg.contains("x1=\"10\""));
+        assert!(svg.contains("y1=\"50\""));
+        assert!(svg.contains("x2=\"190\""));
+        assert!(svg.contains("y2=\"50\""));
+    }
+
+    // --- US-068 tests: draw_edges ---
+
+    fn make_edge(x0: f64, top: f64, x1: f64, bottom: f64) -> Edge {
+        Edge {
+            x0,
+            top,
+            x1,
+            bottom,
+            orientation: Orientation::Horizontal,
+            source: EdgeSource::Line,
+        }
+    }
+
+    #[test]
+    fn test_draw_edges_adds_line_elements() {
+        let mut renderer = SvgRenderer::new(200.0, 200.0);
+        let edges = vec![make_edge(0.0, 100.0, 200.0, 100.0)];
+        renderer.draw_edges(&edges, &DrawStyle::edges_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        let line_count = svg.matches("<line").count();
+        assert_eq!(line_count, 1);
+        assert!(svg.contains("stroke:orange"));
+    }
+
+    // --- US-068 tests: draw_tables ---
+
+    fn make_table() -> Table {
+        Table {
+            bbox: BBox::new(10.0, 10.0, 200.0, 100.0),
+            cells: vec![
+                Cell {
+                    bbox: BBox::new(10.0, 10.0, 100.0, 50.0),
+                    text: Some("A".to_string()),
+                },
+                Cell {
+                    bbox: BBox::new(100.0, 10.0, 200.0, 50.0),
+                    text: Some("B".to_string()),
+                },
+                Cell {
+                    bbox: BBox::new(10.0, 50.0, 100.0, 100.0),
+                    text: Some("C".to_string()),
+                },
+                Cell {
+                    bbox: BBox::new(100.0, 50.0, 200.0, 100.0),
+                    text: Some("D".to_string()),
+                },
+            ],
+            rows: vec![],
+            columns: vec![],
+        }
+    }
+
+    #[test]
+    fn test_draw_tables_adds_cell_rects() {
+        let mut renderer = SvgRenderer::new(300.0, 200.0);
+        let tables = vec![make_table()];
+        renderer.draw_tables(&tables, &DrawStyle::tables_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        // 1 page boundary + 4 cell rects
+        let rect_count = svg.matches("<rect").count();
+        assert_eq!(rect_count, 5);
+        assert!(svg.contains("fill:lightblue"));
+    }
+
+    // --- US-068 tests: mixed overlays ---
+
+    #[test]
+    fn test_svg_with_mixed_objects() {
+        let mut renderer = SvgRenderer::new(400.0, 400.0);
+
+        let chars = vec![make_char("H", 10.0, 10.0, 20.0, 22.0)];
+        let lines = vec![make_line(0.0, 100.0, 400.0, 100.0)];
+        let rects = vec![make_rect(50.0, 50.0, 150.0, 80.0)];
+
+        renderer.draw_chars(&chars, &DrawStyle::chars_default());
+        renderer.draw_lines(&lines, &DrawStyle::lines_default());
+        renderer.draw_rects(&rects, &DrawStyle::rects_default());
+
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        // Verify all object types present
+        assert!(svg.contains("stroke:blue"), "chars overlay");
+        assert!(svg.contains("stroke:red"), "lines overlay");
+        assert!(svg.contains("stroke:green"), "rects overlay");
+        // 1 page boundary rect + 1 char rect + 1 rect overlay = 3 rects, 1 line
+        let rect_count = svg.matches("<rect").count();
+        assert_eq!(rect_count, 3);
+        let line_count = svg.matches("<line").count();
+        assert_eq!(line_count, 1);
+    }
+
+    #[test]
+    fn test_style_customization() {
+        let mut renderer = SvgRenderer::new(100.0, 100.0);
+        let chars = vec![make_char("Z", 5.0, 5.0, 15.0, 17.0)];
+        let custom_style = DrawStyle {
+            fill: Some("yellow".to_string()),
+            stroke: Some("purple".to_string()),
+            stroke_width: 3.0,
+            opacity: 0.5,
+        };
+        renderer.draw_chars(&chars, &custom_style);
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        assert!(svg.contains("fill:yellow"));
+        assert!(svg.contains("stroke:purple"));
+        assert!(svg.contains("stroke-width:3"));
+        assert!(svg.contains("opacity:0.5"));
+    }
+
+    #[test]
+    fn test_empty_draw_no_overlays() {
+        let renderer = SvgRenderer::new(100.0, 100.0);
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        // Only the page boundary rect
+        let rect_count = svg.matches("<rect").count();
+        assert_eq!(rect_count, 1);
+        let line_count = svg.matches("<line").count();
+        assert_eq!(line_count, 0);
+    }
+
+    #[test]
+    fn test_draw_chars_empty_slice() {
+        let mut renderer = SvgRenderer::new(100.0, 100.0);
+        renderer.draw_chars(&[], &DrawStyle::chars_default());
+        let svg = renderer.to_svg(&SvgOptions::default());
+
+        // Only the page boundary rect
+        let rect_count = svg.matches("<rect").count();
+        assert_eq!(rect_count, 1);
     }
 }

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -105,16 +105,16 @@ pub use pdf::{PagesIter, Pdf};
 pub type FilteredPage = CroppedPage;
 pub use pdfplumber_core::{
     Annotation, AnnotationType, BBox, Bookmark, Cell, Char, Color, Ctm, Curve, DashPattern,
-    DedupeOptions, DocumentMetadata, Edge, EdgeSource, EncodingResolver, ExplicitLines, ExtGState,
-    ExtractOptions, ExtractResult, ExtractWarning, FillRule, FontEncoding, GraphicsState,
-    Hyperlink, Image, ImageMetadata, Intersection, Line, LineOrientation, Orientation, PageObject,
-    PaintedPath, Path, PathBuilder, PathSegment, PdfError, Point, Rect, SearchMatch, SearchOptions,
-    StandardEncoding, Strategy, SvgOptions, SvgRenderer, Table, TableFinder, TableSettings,
-    TextBlock, TextDirection, TextLine, TextOptions, UnicodeNorm, Word, WordExtractor, WordOptions,
-    blocks_to_text, cells_to_tables, cluster_lines_into_blocks, cluster_words_into_lines,
-    derive_edges, edge_from_curve, edge_from_line, edges_from_rect, edges_to_intersections,
-    explicit_lines_to_edges, extract_shapes, extract_text_for_cells, image_from_ctm,
-    intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
+    DedupeOptions, DocumentMetadata, DrawStyle, Edge, EdgeSource, EncodingResolver, ExplicitLines,
+    ExtGState, ExtractOptions, ExtractResult, ExtractWarning, FillRule, FontEncoding,
+    GraphicsState, Hyperlink, Image, ImageMetadata, Intersection, Line, LineOrientation,
+    Orientation, PageObject, PaintedPath, Path, PathBuilder, PathSegment, PdfError, Point, Rect,
+    SearchMatch, SearchOptions, StandardEncoding, Strategy, SvgOptions, SvgRenderer, Table,
+    TableFinder, TableSettings, TextBlock, TextDirection, TextLine, TextOptions, UnicodeNorm, Word,
+    WordExtractor, WordOptions, blocks_to_text, cells_to_tables, cluster_lines_into_blocks,
+    cluster_words_into_lines, derive_edges, edge_from_curve, edge_from_line, edges_from_rect,
+    edges_to_intersections, explicit_lines_to_edges, extract_shapes, extract_text_for_cells,
+    image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
     sort_blocks_reading_order, split_lines_at_columns, words_to_edges_stream, words_to_text,
 };
 pub use pdfplumber_parse::{

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -19,7 +19,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "Place SvgRenderer in a new module in pdfplumber-core or pdfplumber crate. Pure string generation — no rendering library needed."
     },
     {
@@ -40,7 +40,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "This + US-069 together recreate Python pdfplumber's visual debugging capability."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -14,6 +14,7 @@
 - **Dedupe pattern**: Character deduplication follows: add DedupeOptions struct + dedupe_chars() algorithm in pdfplumber-core/dedupe.rs → add Page::dedupe_chars() and CroppedPage::dedupe_chars() returning CroppedPage with filtered chars. Algorithm: iterate chars, check each against kept list (same text, positions within tolerance, extra_attrs match), keep first occurrence. Uses from_page_data() helper to build CroppedPage without coordinate adjustment.
 - **ExtractOptions pattern**: Document-level extraction settings go in ExtractOptions (set at Pdf::open() time, used during Pdf::page()). For text processing options (normalization, etc.), add field to ExtractOptions, apply in Pdf::page() after char creation. CLI: add separate clap ValueEnum arg type with conversion method, use open_pdf_with_norm() helper.
 - **Filter pattern**: Custom filtering follows: add PageObject enum in pdfplumber-core/page_object.rs → add Page::filter() and CroppedPage::filter() accepting Fn(&PageObject) -> bool → return CroppedPage with filtered objects (no coordinate adjustment). FilteredPage is a type alias for CroppedPage. Uses from_page_data() for Page, direct struct construction for CroppedPage.
+- **SVG overlay pattern**: SvgRenderer is a builder: `new(w,h)` → `draw_chars/rects/lines/edges/tables(&mut self, items, &DrawStyle)` → `to_svg(&SvgOptions) -> String`. DrawStyle has `fill`, `stroke`, `stroke_width`, `opacity` with per-object-type defaults. Elements accumulate in `Vec<String>` and render between page boundary and `</svg>`. No external SVG library needed.
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
@@ -21,4 +22,29 @@ Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
 
 # Ralph Progress Log - Phase 7: Differentiation - Visual Debugging (SVG), Table Quality, Image Content, Encryption
 Started: 2026년  2월 28일 토요일 17시 04분 35초 KST
+---
+
+## 2026-02-28 - US-067 - Visual debugging - SVG page rendering foundation
+- Implemented `SvgRenderer` struct and `SvgOptions` in `pdfplumber-core/src/svg.rs`
+- Added `Page::to_svg(options)` convenience method in `pdfplumber/src/page.rs`
+- Re-exported `SvgRenderer` and `SvgOptions` from facade crate
+- Files changed: `crates/pdfplumber-core/src/svg.rs` (new), `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`, `crates/pdfplumber/src/page.rs`
+- Dependencies added: none (pure string generation)
+- **Learnings for future iterations:**
+  - BBox fields (`x0`, `top`, `x1`, `bottom`) are public fields, not methods. `width()` and `height()` are methods.
+  - The `#![deny(missing_docs)]` lint is active on both `pdfplumber-core` and `pdfplumber` crates — all public items need doc comments.
+  - SVG pattern: `SvgRenderer::new(width, height)` → `renderer.to_svg(&SvgOptions)` → String. No external SVG library needed.
+---
+
+## 2026-02-28 - US-068 - Visual debugging - object overlay drawing
+- Added `DrawStyle` struct with `fill`, `stroke`, `stroke_width`, `opacity` fields and default style constructors (`chars_default`, `lines_default`, `rects_default`, `edges_default`, `tables_default`)
+- Added `draw_chars()`, `draw_rects()`, `draw_lines()`, `draw_edges()`, `draw_tables()` methods to `SvgRenderer` (accumulates SVG elements rendered by `to_svg()`)
+- Added `pdfplumber debug <FILE> --output <file.svg>` CLI subcommand that generates SVG with all extracted objects overlaid
+- Multi-page support: appends `_pageN` to output filename when multiple pages specified
+- Files changed: `crates/pdfplumber-core/src/svg.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`, `crates/pdfplumber-cli/src/cli.rs`, `crates/pdfplumber-cli/src/main.rs`, `crates/pdfplumber-cli/src/debug_cmd.rs` (new)
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - SvgRenderer uses builder pattern: accumulate elements via `draw_*` methods, then `to_svg()` renders header + page boundary + accumulated elements + close.
+  - `DrawStyle::to_svg_style()` generates inline CSS `style` attribute. Opacity=1.0 is omitted for cleaner SVG.
+  - CLI debug subcommand doesn't need output format variants (text/json/csv) — it only outputs SVG files.
 ---


### PR DESCRIPTION
## Summary
- Added `DrawStyle` struct with per-object-type defaults (chars=blue, lines=red, rects=green, edges=orange, tables=lightblue)
- Added `draw_chars()`, `draw_rects()`, `draw_lines()`, `draw_edges()`, `draw_tables()` methods to `SvgRenderer`
- Added `pdfplumber debug <FILE> --output <file.svg>` CLI subcommand for visual debugging SVG generation

## Test plan
- [x] Unit tests for DrawStyle defaults and SVG style generation
- [x] Unit tests for each draw method (chars, rects, lines, edges, tables)
- [x] Unit tests for mixed objects overlay and custom style
- [x] CLI argument parsing tests for debug subcommand
- [x] All quality checks pass: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)