### PR TITLE
feat: US-072 - Encrypted PDF support - password-based decryption

### DIFF
--- a/crates/pdfplumber-cli/src/annots_cmd.rs
+++ b/crates/pdfplumber-cli/src/annots_cmd.rs
@@ -3,10 +3,15 @@ use std::path::Path;
 use pdfplumber::Annotation;
 
 use crate::cli::OutputFormat;
-use crate::shared::{ProgressReporter, csv_escape, open_pdf, resolve_pages};
+use crate::shared::{ProgressReporter, csv_escape, open_pdf_full, resolve_pages};
 
-pub fn run(file: &Path, pages: Option<&str>, format: &OutputFormat) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+pub fn run(
+    file: &Path,
+    pages: Option<&str>,
+    format: &OutputFormat,
+    password: Option<&str>,
+) -> Result<(), i32> {
+    let pdf = open_pdf_full(file, None, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let progress = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-cli/src/bookmarks_cmd.rs
+++ b/crates/pdfplumber-cli/src/bookmarks_cmd.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 use pdfplumber::Bookmark;
 
 use crate::cli::TextFormat;
-use crate::shared::open_pdf;
+use crate::shared::open_pdf_full;
 
-pub fn run(file: &Path, format: &TextFormat) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+pub fn run(file: &Path, format: &TextFormat, password: Option<&str>) -> Result<(), i32> {
+    let pdf = open_pdf_full(file, None, password)?;
     let bookmarks = pdf.bookmarks();
 
     match format {

--- a/crates/pdfplumber-cli/src/chars_cmd.rs
+++ b/crates/pdfplumber-cli/src/chars_cmd.rs
@@ -3,15 +3,16 @@ use std::path::Path;
 use pdfplumber::{Char, UnicodeNorm};
 
 use crate::cli::OutputFormat;
-use crate::shared::{ProgressReporter, direction_str, open_pdf_with_norm, resolve_pages};
+use crate::shared::{ProgressReporter, direction_str, open_pdf_full, resolve_pages};
 
 pub fn run(
     file: &Path,
     pages: Option<&str>,
     format: &OutputFormat,
     unicode_norm: Option<UnicodeNorm>,
+    password: Option<&str>,
 ) -> Result<(), i32> {
-    let pdf = open_pdf_with_norm(file, unicode_norm)?;
+    let pdf = open_pdf_full(file, unicode_norm, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let progress = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-cli/src/cli.rs
+++ b/crates/pdfplumber-cli/src/cli.rs
@@ -34,6 +34,10 @@ pub enum Commands {
         /// Apply Unicode normalization to extracted text
         #[arg(long, value_enum)]
         unicode_norm: Option<UnicodeNormArg>,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Extract individual characters with coordinates
@@ -53,6 +57,10 @@ pub enum Commands {
         /// Apply Unicode normalization to extracted text
         #[arg(long, value_enum)]
         unicode_norm: Option<UnicodeNormArg>,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Extract words with bounding box coordinates
@@ -80,6 +88,10 @@ pub enum Commands {
         /// Apply Unicode normalization to extracted text
         #[arg(long, value_enum)]
         unicode_norm: Option<UnicodeNormArg>,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Detect and extract tables from PDF pages
@@ -111,6 +123,10 @@ pub enum Commands {
         /// Text tolerance for assigning text to cells (default: 3.0)
         #[arg(long, default_value_t = 3.0)]
         text_tolerance: f64,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Display PDF metadata and page information
@@ -126,6 +142,10 @@ pub enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value_t = TextFormat::Text)]
         format: TextFormat,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Extract annotations from PDF pages
@@ -141,6 +161,10 @@ pub enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Extract hyperlinks from PDF pages
@@ -156,6 +180,10 @@ pub enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Extract bookmarks (outline / table of contents) from PDF
@@ -167,6 +195,10 @@ pub enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value_t = TextFormat::Text)]
         format: TextFormat,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Generate debug SVG with object overlays
@@ -186,6 +218,10 @@ pub enum Commands {
         /// Show table detection pipeline (edges, intersections, cells, tables)
         #[arg(long)]
         tables: bool,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Search for text patterns with position information
@@ -213,6 +249,10 @@ pub enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// List or extract images from PDF pages
@@ -236,6 +276,10 @@ pub enum Commands {
         /// Output directory for extracted images (default: current directory)
         #[arg(long, value_name = "DIR")]
         output_dir: Option<PathBuf>,
+
+        /// Password for encrypted PDFs
+        #[arg(long)]
+        password: Option<String>,
     },
 }
 
@@ -460,6 +504,7 @@ mod tests {
                 snap_tolerance,
                 join_tolerance,
                 text_tolerance,
+                ..
             } => {
                 assert_eq!(file, &PathBuf::from("doc.pdf"));
                 assert_eq!(pages.as_deref(), Some("2-4"));
@@ -783,6 +828,7 @@ mod tests {
                 ref pages,
                 ref output,
                 tables,
+                ..
             } => {
                 assert_eq!(file, &PathBuf::from("test.pdf"));
                 assert!(pages.is_none());
@@ -918,6 +964,70 @@ mod tests {
                 assert!(matches!(format, OutputFormat::Text));
             }
             _ => panic!("expected Images subcommand"),
+        }
+    }
+
+    // --- Password flag tests ---
+
+    #[test]
+    fn parse_text_with_password() {
+        let cli = Cli::parse_from(["pdfplumber", "text", "test.pdf", "--password", "secret123"]);
+        match cli.command {
+            Commands::Text { ref password, .. } => {
+                assert_eq!(password.as_deref(), Some("secret123"));
+            }
+            _ => panic!("expected Text subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_text_without_password() {
+        let cli = Cli::parse_from(["pdfplumber", "text", "test.pdf"]);
+        match cli.command {
+            Commands::Text { ref password, .. } => {
+                assert!(password.is_none());
+            }
+            _ => panic!("expected Text subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_info_with_password() {
+        let cli = Cli::parse_from(["pdfplumber", "info", "test.pdf", "--password", "mypass"]);
+        match cli.command {
+            Commands::Info { ref password, .. } => {
+                assert_eq!(password.as_deref(), Some("mypass"));
+            }
+            _ => panic!("expected Info subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_tables_with_password() {
+        let cli = Cli::parse_from(["pdfplumber", "tables", "test.pdf", "--password", "pw"]);
+        match cli.command {
+            Commands::Tables { ref password, .. } => {
+                assert_eq!(password.as_deref(), Some("pw"));
+            }
+            _ => panic!("expected Tables subcommand"),
+        }
+    }
+
+    #[test]
+    fn parse_search_with_password() {
+        let cli = Cli::parse_from([
+            "pdfplumber",
+            "search",
+            "test.pdf",
+            "pattern",
+            "--password",
+            "pw",
+        ]);
+        match cli.command {
+            Commands::Search { ref password, .. } => {
+                assert_eq!(password.as_deref(), Some("pw"));
+            }
+            _ => panic!("expected Search subcommand"),
         }
     }
 }

--- a/crates/pdfplumber-cli/src/debug_cmd.rs
+++ b/crates/pdfplumber-cli/src/debug_cmd.rs
@@ -3,10 +3,16 @@ use std::path::Path;
 
 use pdfplumber::{DrawStyle, SvgDebugOptions, SvgOptions, SvgRenderer, TableSettings};
 
-use crate::shared::{open_pdf, resolve_pages};
+use crate::shared::{open_pdf_full, resolve_pages};
 
-pub fn run(file: &Path, pages: Option<&str>, output: &Path, tables: bool) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+pub fn run(
+    file: &Path,
+    pages: Option<&str>,
+    output: &Path,
+    tables: bool,
+    password: Option<&str>,
+) -> Result<(), i32> {
+    let pdf = open_pdf_full(file, None, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
 
     // Generate SVG for each page; if multiple pages, append page number to filename

--- a/crates/pdfplumber-cli/src/images_cmd.rs
+++ b/crates/pdfplumber-cli/src/images_cmd.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::cli::OutputFormat;
-use crate::shared::{ProgressReporter, open_pdf, resolve_pages};
+use crate::shared::{ProgressReporter, open_pdf_full, resolve_pages};
 
 pub fn run(
     file: &Path,
@@ -10,8 +10,9 @@ pub fn run(
     format: &OutputFormat,
     extract: bool,
     output_dir: Option<&Path>,
+    password: Option<&str>,
 ) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+    let pdf = open_pdf_full(file, None, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let reporter = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-cli/src/info_cmd.rs
+++ b/crates/pdfplumber-cli/src/info_cmd.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use pdfplumber::{BBox, TableSettings};
 
 use crate::cli::TextFormat;
-use crate::shared::{ProgressReporter, open_pdf, resolve_pages};
+use crate::shared::{ProgressReporter, open_pdf_full, resolve_pages};
 
 fn format_bbox(b: &BBox) -> String {
     format!("[{:.2}, {:.2}, {:.2}, {:.2}]", b.x0, b.top, b.x1, b.bottom)
@@ -13,8 +13,13 @@ fn bbox_to_json(b: &BBox) -> serde_json::Value {
     serde_json::json!([b.x0, b.top, b.x1, b.bottom])
 }
 
-pub fn run(file: &Path, pages: Option<&str>, format: &TextFormat) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+pub fn run(
+    file: &Path,
+    pages: Option<&str>,
+    format: &TextFormat,
+    password: Option<&str>,
+) -> Result<(), i32> {
+    let pdf = open_pdf_full(file, None, password)?;
     let page_count = pdf.page_count();
     let page_indices = resolve_pages(pages, page_count)?;
     let progress = ProgressReporter::new(page_indices.len());

--- a/crates/pdfplumber-cli/src/links_cmd.rs
+++ b/crates/pdfplumber-cli/src/links_cmd.rs
@@ -3,10 +3,15 @@ use std::path::Path;
 use pdfplumber::Hyperlink;
 
 use crate::cli::OutputFormat;
-use crate::shared::{ProgressReporter, csv_escape, open_pdf, resolve_pages};
+use crate::shared::{ProgressReporter, csv_escape, open_pdf_full, resolve_pages};
 
-pub fn run(file: &Path, pages: Option<&str>, format: &OutputFormat) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+pub fn run(
+    file: &Path,
+    pages: Option<&str>,
+    format: &OutputFormat,
+    password: Option<&str>,
+) -> Result<(), i32> {
+    let pdf = open_pdf_full(file, None, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let progress = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-cli/src/main.rs
+++ b/crates/pdfplumber-cli/src/main.rs
@@ -26,23 +26,27 @@ fn main() {
             ref format,
             layout,
             ref unicode_norm,
+            ref password,
         } => text_cmd::run(
             file,
             pages.as_deref(),
             format,
             layout,
             unicode_norm.as_ref().map(|n| n.to_unicode_norm()),
+            password.as_deref(),
         ),
         cli::Commands::Chars {
             ref file,
             ref pages,
             ref format,
             ref unicode_norm,
+            ref password,
         } => chars_cmd::run(
             file,
             pages.as_deref(),
             format,
             unicode_norm.as_ref().map(|n| n.to_unicode_norm()),
+            password.as_deref(),
         ),
         cli::Commands::Words {
             ref file,
@@ -51,6 +55,7 @@ fn main() {
             x_tolerance,
             y_tolerance,
             ref unicode_norm,
+            ref password,
         } => words_cmd::run(
             file,
             pages.as_deref(),
@@ -58,6 +63,7 @@ fn main() {
             x_tolerance,
             y_tolerance,
             unicode_norm.as_ref().map(|n| n.to_unicode_norm()),
+            password.as_deref(),
         ),
         cli::Commands::Tables {
             ref file,
@@ -67,6 +73,7 @@ fn main() {
             snap_tolerance,
             join_tolerance,
             text_tolerance,
+            ref password,
         } => tables_cmd::run(
             file,
             pages.as_deref(),
@@ -75,32 +82,38 @@ fn main() {
             snap_tolerance,
             join_tolerance,
             text_tolerance,
+            password.as_deref(),
         ),
         cli::Commands::Info {
             ref file,
             ref pages,
             ref format,
-        } => info_cmd::run(file, pages.as_deref(), format),
+            ref password,
+        } => info_cmd::run(file, pages.as_deref(), format, password.as_deref()),
         cli::Commands::Annots {
             ref file,
             ref pages,
             ref format,
-        } => annots_cmd::run(file, pages.as_deref(), format),
+            ref password,
+        } => annots_cmd::run(file, pages.as_deref(), format, password.as_deref()),
         cli::Commands::Links {
             ref file,
             ref pages,
             ref format,
-        } => links_cmd::run(file, pages.as_deref(), format),
+            ref password,
+        } => links_cmd::run(file, pages.as_deref(), format, password.as_deref()),
         cli::Commands::Bookmarks {
             ref file,
             ref format,
-        } => bookmarks_cmd::run(file, format),
+            ref password,
+        } => bookmarks_cmd::run(file, format, password.as_deref()),
         cli::Commands::Debug {
             ref file,
             ref pages,
             ref output,
             tables,
-        } => debug_cmd::run(file, pages.as_deref(), output, tables),
+            ref password,
+        } => debug_cmd::run(file, pages.as_deref(), output, tables, password.as_deref()),
         cli::Commands::Search {
             ref file,
             ref pattern,
@@ -108,6 +121,7 @@ fn main() {
             case_insensitive,
             no_regex,
             ref format,
+            ref password,
         } => search_cmd::run(
             file,
             pattern,
@@ -115,6 +129,7 @@ fn main() {
             case_insensitive,
             no_regex,
             format,
+            password.as_deref(),
         ),
         cli::Commands::Images {
             ref file,
@@ -122,12 +137,14 @@ fn main() {
             ref format,
             extract,
             ref output_dir,
+            ref password,
         } => images_cmd::run(
             file,
             pages.as_deref(),
             format,
             extract,
             output_dir.as_deref(),
+            password.as_deref(),
         ),
     };
 

--- a/crates/pdfplumber-cli/src/search_cmd.rs
+++ b/crates/pdfplumber-cli/src/search_cmd.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use pdfplumber::SearchOptions;
 
 use crate::cli::OutputFormat;
-use crate::shared::{ProgressReporter, csv_escape, open_pdf, resolve_pages};
+use crate::shared::{ProgressReporter, csv_escape, open_pdf_full, resolve_pages};
 
 pub fn run(
     file: &Path,
@@ -12,8 +12,9 @@ pub fn run(
     case_insensitive: bool,
     no_regex: bool,
     format: &OutputFormat,
+    password: Option<&str>,
 ) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+    let pdf = open_pdf_full(file, None, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let progress = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-cli/src/tables_cmd.rs
+++ b/crates/pdfplumber-cli/src/tables_cmd.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 use pdfplumber::{Strategy, TableSettings};
 
 use crate::cli::{OutputFormat, TableStrategy};
-use crate::shared::{ProgressReporter, csv_escape, open_pdf, resolve_pages};
+use crate::shared::{ProgressReporter, csv_escape, open_pdf_full, resolve_pages};
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     file: &Path,
     pages: Option<&str>,
@@ -13,8 +14,9 @@ pub fn run(
     snap_tolerance: f64,
     join_tolerance: f64,
     text_tolerance: f64,
+    password: Option<&str>,
 ) -> Result<(), i32> {
-    let pdf = open_pdf(file)?;
+    let pdf = open_pdf_full(file, None, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let progress = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-cli/src/text_cmd.rs
+++ b/crates/pdfplumber-cli/src/text_cmd.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use pdfplumber::{TextOptions, UnicodeNorm};
 
 use crate::cli::TextFormat;
-use crate::shared::{ProgressReporter, open_pdf_with_norm, resolve_pages};
+use crate::shared::{ProgressReporter, open_pdf_full, resolve_pages};
 
 pub fn run(
     file: &Path,
@@ -11,8 +11,9 @@ pub fn run(
     format: &TextFormat,
     layout: bool,
     unicode_norm: Option<UnicodeNorm>,
+    password: Option<&str>,
 ) -> Result<(), i32> {
-    let pdf = open_pdf_with_norm(file, unicode_norm)?;
+    let pdf = open_pdf_full(file, unicode_norm, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let progress = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-cli/src/words_cmd.rs
+++ b/crates/pdfplumber-cli/src/words_cmd.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use pdfplumber::{UnicodeNorm, WordOptions};
 
 use crate::cli::OutputFormat;
-use crate::shared::{ProgressReporter, direction_str, open_pdf_with_norm, resolve_pages};
+use crate::shared::{ProgressReporter, direction_str, open_pdf_full, resolve_pages};
 
 pub fn run(
     file: &Path,
@@ -12,8 +12,9 @@ pub fn run(
     x_tolerance: f64,
     y_tolerance: f64,
     unicode_norm: Option<UnicodeNorm>,
+    password: Option<&str>,
 ) -> Result<(), i32> {
-    let pdf = open_pdf_with_norm(file, unicode_norm)?;
+    let pdf = open_pdf_full(file, unicode_norm, password)?;
     let page_indices = resolve_pages(pages, pdf.page_count())?;
     let progress = ProgressReporter::new(page_indices.len());
 

--- a/crates/pdfplumber-core/src/error.rs
+++ b/crates/pdfplumber-core/src/error.rs
@@ -25,6 +25,10 @@ pub enum PdfError {
     InterpreterError(String),
     /// A configured resource limit was exceeded.
     ResourceLimitExceeded(String),
+    /// The PDF is encrypted and requires a password to open.
+    PasswordRequired,
+    /// The supplied password is incorrect for this encrypted PDF.
+    InvalidPassword,
     /// Any other error not covered by specific variants.
     Other(String),
 }
@@ -37,6 +41,8 @@ impl fmt::Display for PdfError {
             PdfError::FontError(msg) => write!(f, "font error: {msg}"),
             PdfError::InterpreterError(msg) => write!(f, "interpreter error: {msg}"),
             PdfError::ResourceLimitExceeded(msg) => write!(f, "resource limit exceeded: {msg}"),
+            PdfError::PasswordRequired => write!(f, "PDF is encrypted and requires a password"),
+            PdfError::InvalidPassword => write!(f, "the supplied password is incorrect"),
             PdfError::Other(msg) => write!(f, "{msg}"),
         }
     }
@@ -250,6 +256,32 @@ mod tests {
     fn pdf_error_resource_limit_exceeded() {
         let err = PdfError::ResourceLimitExceeded("too many objects".to_string());
         assert_eq!(err.to_string(), "resource limit exceeded: too many objects");
+    }
+
+    #[test]
+    fn pdf_error_password_required() {
+        let err = PdfError::PasswordRequired;
+        assert_eq!(err.to_string(), "PDF is encrypted and requires a password");
+    }
+
+    #[test]
+    fn pdf_error_invalid_password() {
+        let err = PdfError::InvalidPassword;
+        assert_eq!(err.to_string(), "the supplied password is incorrect");
+    }
+
+    #[test]
+    fn pdf_error_password_required_clone_and_eq() {
+        let err1 = PdfError::PasswordRequired;
+        let err2 = err1.clone();
+        assert_eq!(err1, err2);
+    }
+
+    #[test]
+    fn pdf_error_invalid_password_clone_and_eq() {
+        let err1 = PdfError::InvalidPassword;
+        let err2 = err1.clone();
+        assert_eq!(err1, err2);
     }
 
     #[test]

--- a/crates/pdfplumber-parse/Cargo.toml
+++ b/crates/pdfplumber-parse/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["parser-implementations"]
 pdfplumber-core = { version = "0.1.0", path = "../pdfplumber-core" }
 lopdf = { version = "0.34", default-features = false, features = ["nom_parser"] }
 thiserror = "2"
+
+[dev-dependencies]
+md5 = "0.7"

--- a/crates/pdfplumber-parse/src/backend.rs
+++ b/crates/pdfplumber-parse/src/backend.rs
@@ -45,7 +45,19 @@ pub trait PdfBackend {
     /// # Errors
     ///
     /// Returns an error if the bytes do not represent a valid PDF document.
+    /// If the document is encrypted, returns [`PdfError::PasswordRequired`].
     fn open(bytes: &[u8]) -> Result<Self::Document, Self::Error>;
+
+    /// Parse PDF bytes into a document, decrypting with the given password.
+    ///
+    /// Supports both user and owner passwords. If the PDF is not encrypted,
+    /// the password is ignored and the document opens normally.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PdfError::InvalidPassword`] if the password is incorrect.
+    /// Returns other errors if the bytes are not a valid PDF document.
+    fn open_with_password(bytes: &[u8], password: &[u8]) -> Result<Self::Document, Self::Error>;
 
     /// Return the number of pages in the document.
     fn page_count(doc: &Self::Document) -> usize;
@@ -294,6 +306,14 @@ mod tests {
                 });
             }
             Ok(MockDocument { pages })
+        }
+
+        fn open_with_password(
+            bytes: &[u8],
+            _password: &[u8],
+        ) -> Result<Self::Document, Self::Error> {
+            // Mock: just delegates to open (no encryption support in mock)
+            Self::open(bytes)
         }
 
         fn page_count(doc: &Self::Document) -> usize {

--- a/crates/pdfplumber-parse/src/error.rs
+++ b/crates/pdfplumber-parse/src/error.rs
@@ -116,4 +116,18 @@ mod tests {
         let err: Box<dyn std::error::Error> = Box::new(BackendError::Parse("test".to_string()));
         assert!(err.to_string().contains("test"));
     }
+
+    #[test]
+    fn backend_error_core_password_required_passthrough() {
+        let backend = BackendError::Core(PdfError::PasswordRequired);
+        let pdf_err: PdfError = backend.into();
+        assert_eq!(pdf_err, PdfError::PasswordRequired);
+    }
+
+    #[test]
+    fn backend_error_core_invalid_password_passthrough() {
+        let backend = BackendError::Core(PdfError::InvalidPassword);
+        let pdf_err: PdfError = backend.into();
+        assert_eq!(pdf_err, PdfError::InvalidPassword);
+    }
 }

--- a/crates/pdfplumber/Cargo.toml
+++ b/crates/pdfplumber/Cargo.toml
@@ -23,6 +23,7 @@ rayon = { version = "1.10", optional = true }
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 lopdf = "0.34"
+md5 = "0.7"
 serde_json = "1.0"
 
 [[bench]]

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -118,7 +118,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 6,
-      "passes": false,
+      "passes": true,
       "notes": "lopdf has some encryption support. Check lopdf::Document::decrypt() capabilities. May need to add decryption crate as dependency if lopdf support is insufficient."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -17,6 +17,7 @@
 - **SVG overlay pattern**: SvgRenderer is a builder: `new(w,h)` → `draw_chars/rects/lines/edges/tables/intersections/cells(&mut self, items, &DrawStyle)` → `to_svg(&SvgOptions) -> String`. DrawStyle has `fill`, `stroke`, `stroke_width`, `opacity` with per-object-type defaults. Elements accumulate in `Vec<String>` and render between page boundary and `</svg>`. No external SVG library needed.
 - **Debug pipeline pattern**: For exposing intermediate pipeline results, add a `*_debug()` method returning a struct with all stages. `TableFinder::find_tables_debug()` returns `TableFinderDebug { edges, intersections, cells, tables }`. `Page::debug_tablefinder_svg()` runs the pipeline and renders each stage with distinct styles via `SvgDebugOptions` toggle flags.
 - **Image content pattern**: Image content extraction follows: add `extract_image_content(doc, page, name)` to PdfBackend trait → implement in LopdfBackend (get XObject stream, check /Filter, decode accordingly) → add `Pdf::extract_image_content()` and `Pdf::extract_images_with_content()` facade methods. Filter detection: DCTDecode→Jpeg (raw bytes), FlateDecode→Raw (decompressed), JBIG2Decode→Jbig2, CCITTFaxDecode→CcittFax, no filter→Raw. Chained filters use lopdf `decompressed_content()`.
+- **Encryption pattern**: Encrypted PDF support follows: add `open_with_password(bytes, password)` to PdfBackend trait → implement in LopdfBackend (load → check `is_encrypted()` → call `decrypt(password)`) → add `Pdf::open_with_password()` and `Pdf::open_file_with_password()` facade methods. `open()` without password returns `PdfError::PasswordRequired` for encrypted PDFs. Wrong password returns `PdfError::InvalidPassword`. Unencrypted PDFs ignore the password. CLI: add `--password` flag to all subcommands, pass through `open_pdf_full(file, unicode_norm, password)`. Test encrypted PDFs created programmatically using RC4 + MD5 (PAD_BYTES padding, Algorithm 3.2-3.4 from PDF spec).
 
 # Ralph Progress Log
 Started: 2026년  2월 28일 토요일 15시 35분 07초 KST
@@ -106,4 +107,25 @@ Started: 2026년  2월 28일 토요일 17시 04분 35초 KST
   - The `resolve_ref()` helper was duplicated from interpreter.rs into lopdf_backend.rs since it's a private function. Consider making it a shared utility.
   - `Pdf::extract_images_with_content()` silently skips images that can't be extracted (e.g., inline images) rather than erroring. This is intentional for robustness.
   - Filter detection: PDF image XObjects store filters as either a single `/Name` or an array of names. Both cases need handling.
+---
+
+## 2026-02-28 - US-072 - Encrypted PDF support - password-based decryption
+- Added `PdfError::PasswordRequired` and `PdfError::InvalidPassword` error variants to `pdfplumber-core/src/error.rs`
+- Added `open_with_password(bytes, password)` method to `PdfBackend` trait in `pdfplumber-parse/src/backend.rs`
+- Implemented `open_with_password` in `LopdfBackend`: loads doc → checks `is_encrypted()` → calls `document.decrypt(password)` → maps errors to `PasswordRequired`/`InvalidPassword`
+- Modified `LopdfBackend::open()` to return `PasswordRequired` when encrypted PDF opened without password
+- Added `Pdf::open_with_password()` and `Pdf::open_file_with_password()` facade methods; refactored shared logic into `from_doc()`
+- Added `--password` flag to all 11 CLI subcommands (Text, Chars, Words, Tables, Info, Annots, Links, Bookmarks, Debug, Search, Images)
+- Replaced `open_pdf`/`open_pdf_with_norm` with unified `open_pdf_full(file, unicode_norm, password)` in CLI shared.rs
+- Encryption support: RC4 40-bit (V=1, R=2) and 128-bit (V=2, R=3) via lopdf's built-in `Document::decrypt()`
+- AES encryption (V=4/5) not supported by lopdf 0.34 — returns parse error
+- Files changed: `crates/pdfplumber-core/src/error.rs`, `crates/pdfplumber-parse/src/backend.rs`, `crates/pdfplumber-parse/src/lopdf_backend.rs`, `crates/pdfplumber-parse/Cargo.toml`, `crates/pdfplumber/src/pdf.rs`, `crates/pdfplumber/Cargo.toml`, `crates/pdfplumber-cli/src/cli.rs`, `crates/pdfplumber-cli/src/main.rs`, `crates/pdfplumber-cli/src/shared.rs`, `crates/pdfplumber-cli/src/text_cmd.rs`, `crates/pdfplumber-cli/src/chars_cmd.rs`, `crates/pdfplumber-cli/src/words_cmd.rs`, `crates/pdfplumber-cli/src/tables_cmd.rs`, `crates/pdfplumber-cli/src/info_cmd.rs`, `crates/pdfplumber-cli/src/annots_cmd.rs`, `crates/pdfplumber-cli/src/links_cmd.rs`, `crates/pdfplumber-cli/src/bookmarks_cmd.rs`, `crates/pdfplumber-cli/src/debug_cmd.rs`, `crates/pdfplumber-cli/src/search_cmd.rs`, `crates/pdfplumber-cli/src/images_cmd.rs`
+- Dependencies added: `md5 = "0.7"` as dev-dependency for pdfplumber-parse and pdfplumber (test-only, for creating encrypted test PDFs)
+- **Learnings for future iterations:**
+  - lopdf 0.34 supports RC4 encryption (V=1,2, R=2,3) but NOT AES (V=4,5). `Document::decrypt()` modifies the document in-place, decrypting all String/Stream objects and removing the /Encrypt entry from trailer.
+  - `Document::is_encrypted()` simply checks if `/Encrypt` key exists in trailer. After successful `decrypt()`, the key is removed.
+  - For creating encrypted test PDFs programmatically: use PDF spec Algorithms 3.2-3.4. Compute /O via MD5(padded_password)→RC4_encrypt(padded_user_pw). Compute encryption key via MD5(padded_pw + /O + /P + file_id). Compute /U via RC4(enc_key, PAD_BYTES). Encrypt objects with per-object key MD5(enc_key + obj_num_LE + gen_num_LE).
+  - RC4 is symmetric — `encrypt(key, data)` and `decrypt(key, data)` are the same operation. lopdf's `rc4` module is NOT public, so tests need their own RC4 implementation.
+  - Rust 2024 edition disallows explicit `ref mut` in pattern matching on mutable references — use bare identifiers instead.
+  - `Pdf` struct doesn't implement `Debug`, so `assert_eq!(result.unwrap_err(), ...)` fails — use `match` for error assertions instead.
 ---


### PR DESCRIPTION
## Summary

- Add password-based decryption for encrypted PDFs with `Pdf::open_with_password()` and `Pdf::open_file_with_password()` facade methods
- Introduce `PdfError::PasswordRequired` and `PdfError::InvalidPassword` error variants for clear error handling
- Add `--password` flag to all 11 CLI subcommands via unified `open_pdf_full()` helper
- Support RC4 encryption (V=1,2, R=2,3) through lopdf's `Document::decrypt()`
- Include comprehensive tests with programmatically generated RC4-encrypted PDFs

## Key Changes

- **Core errors** (`pdfplumber-core/src/error.rs`): New `PasswordRequired` and `InvalidPassword` variants
- **Backend trait** (`pdfplumber-parse/src/backend.rs`): Added `open_with_password()` method
- **LopdfBackend** (`pdfplumber-parse/src/lopdf_backend.rs`): Implemented encryption detection in `open()` and decryption in `open_with_password()`
- **Facade** (`pdfplumber/src/pdf.rs`): `open_with_password()`, `open_file_with_password()`, internal `from_doc()` refactor
- **CLI** (all 11 subcommands): `--password` flag, unified `open_pdf_full()` replacing `open_pdf`/`open_pdf_with_norm`

## Test Plan

- [x] Backend tests: encrypted PDF detection, correct/wrong password, unencrypted passthrough
- [x] Facade tests: open_with_password, file_with_password, password_required, wrong_password
- [x] CLI tests: password flag parsing for text, info, tables, search subcommands
- [x] All existing tests remain green (1312+ tests)
- [x] `cargo fmt`, `cargo clippy`, `cargo check` all pass

Related: US-072 from Phase 7 PRD