### PR TITLE
ci: add PyPI and npm publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
 
+  # ── crates.io ──────────────────────────────────────────────
+
   publish:
     name: Publish to crates.io
     needs: ci
@@ -59,3 +61,129 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+  # ── PyPI (maturin wheels + sdist) ──────────────────────────
+
+  build-wheels:
+    name: Build wheel (${{ matrix.os }}, ${{ matrix.target }})
+    needs: ci
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ── Linux ──
+          - os: linux
+            runner: ubuntu-latest
+            target: x86_64
+            manylinux: auto
+          - os: linux
+            runner: ubuntu-latest
+            target: aarch64
+            manylinux: auto
+          # ── macOS ──
+          - os: macos
+            runner: macos-13
+            target: x86_64
+          - os: macos
+            runner: macos-14
+            target: aarch64
+          # ── Windows ──
+          - os: windows
+            runner: windows-latest
+            target: x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        if: matrix.os != 'linux'
+        with:
+          python-version: |
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: >-
+            --release
+            --out dist
+            --find-interpreter
+            --manifest-path crates/pdfplumber-py/Cargo.toml
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          path: dist
+
+  build-sdist:
+    name: Build sdist
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: >-
+            --out dist
+            --manifest-path crates/pdfplumber-py/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pdfplumber-rs
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  # ── npm (wasm-pack) ────────────────────────────────────────
+
+  publish-npm:
+    name: Publish to npm
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Build WASM package
+        run: wasm-pack build --target bundler --out-dir pkg crates/pdfplumber-wasm
+
+      - name: Copy hand-authored type definitions
+        run: cp crates/pdfplumber-wasm/pdfplumber-wasm.d.ts crates/pdfplumber-wasm/pkg/pdfplumber_wasm.d.ts
+
+      - name: Publish to npm
+        run: npm publish crates/pdfplumber-wasm/pkg --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add **PyPI publishing** via maturin: `build-wheels` (5 matrix jobs across Linux/macOS/Windows × x86_64/aarch64), `build-sdist`, and `publish-pypi` jobs
- Add **npm publishing** via wasm-pack: `publish-npm` job that builds WASM package and copies hand-authored TypeScript definitions
- All new jobs run in parallel with the existing crates.io pipeline (gated on `ci` passing)

## Job dependency graph
```
ci
├── publish       (crates.io — unchanged)
│   └── release   (GitHub Release — unchanged)
├── build-wheels  (maturin build, 5 matrix combinations)
│   └─┐
├── build-sdist   │
│   └─┤
│     publish-pypi (upload to PyPI)
└── publish-npm   (wasm-pack build + npm publish)
```

## Manual setup required
- Add `PYPI_API_TOKEN` secret — PyPI API token scoped to the `pdfplumber-rs` project
- Add `NPM_TOKEN` secret — npm Automation token
- Create a `pypi` GitHub environment (used by `publish-pypi` job for deployment protection)

## Test plan
- [ ] Push a `v*.*.*` tag and verify the full workflow runs
- [ ] Verify `build-wheels` produces wheels for all 5 OS/target combinations
- [ ] Verify `build-sdist` produces an sdist
- [ ] Verify `publish-pypi` uploads all artifacts to PyPI
- [ ] Verify `publish-npm` publishes the WASM package to npm
- [ ] Verify existing crates.io publish + GitHub Release still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)