### PR TITLE
fix: resolve PyPI and npm publish auth failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,11 +148,6 @@ jobs:
     name: Publish to PyPI
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pdfplumber-rs
-    permissions:
-      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -190,7 +185,7 @@ jobs:
 
       - name: Publish to npm
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
           npm publish crates/pdfplumber-wasm/pkg --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- **PyPI**: Remove OIDC trusted publishing (`id-token: write`, `environment`) — causes `invalid-publisher` error since no Trusted Publisher is configured on PyPI. Uses `PYPI_API_TOKEN` secret directly instead.
- **npm**: Use `npm config set` for auth token instead of writing `~/.npmrc`, which was being overridden by `NPM_CONFIG_USERCONFIG` env var from `actions/setup-node`.

## Test plan
- [ ] Verify `publish-pypi` authenticates and uploads successfully
- [ ] Verify `publish-npm` authenticates and publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)