### PR TITLE
feat: US-089 - Extract image stream data (pixel bytes)

### DIFF
--- a/crates/pdfplumber-core/src/error.rs
+++ b/crates/pdfplumber-core/src/error.rs
@@ -207,6 +207,12 @@ pub struct ExtractOptions {
     pub collect_warnings: bool,
     /// Unicode normalization form to apply to extracted character text (default: None).
     pub unicode_norm: UnicodeNorm,
+    /// Whether to extract image stream data into Image structs (default: false).
+    ///
+    /// When enabled, each `Image` will have its `data`, `filter`, and `mime_type`
+    /// fields populated with the raw stream bytes and encoding information.
+    /// Disabled by default to avoid memory overhead for large images.
+    pub extract_image_data: bool,
 }
 
 impl Default for ExtractOptions {
@@ -217,6 +223,7 @@ impl Default for ExtractOptions {
             max_stream_bytes: 100 * 1024 * 1024,
             collect_warnings: true,
             unicode_norm: UnicodeNorm::None,
+            extract_image_data: false,
         }
     }
 }
@@ -443,6 +450,7 @@ mod tests {
         assert_eq!(opts.max_stream_bytes, 100 * 1024 * 1024);
         assert!(opts.collect_warnings);
         assert_eq!(opts.unicode_norm, UnicodeNorm::None);
+        assert!(!opts.extract_image_data);
     }
 
     #[test]
@@ -453,11 +461,13 @@ mod tests {
             max_stream_bytes: 10 * 1024 * 1024,
             collect_warnings: false,
             unicode_norm: UnicodeNorm::None,
+            extract_image_data: true,
         };
         assert_eq!(opts.max_recursion_depth, 5);
         assert_eq!(opts.max_objects_per_page, 50_000);
         assert_eq!(opts.max_stream_bytes, 10 * 1024 * 1024);
         assert!(!opts.collect_warnings);
+        assert!(opts.extract_image_data);
     }
 
     #[test]

--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -91,7 +91,7 @@ pub use form_field::{FieldType, FormField};
 pub use geometry::{BBox, Ctm, Orientation, Point};
 pub use html::{HtmlOptions, HtmlRenderer};
 pub use hyperlink::Hyperlink;
-pub use images::{Image, ImageContent, ImageFormat, ImageMetadata, image_from_ctm};
+pub use images::{Image, ImageContent, ImageFilter, ImageFormat, ImageMetadata, image_from_ctm};
 pub use layout::{
     TextBlock, TextLine, TextOptions, blocks_to_text, cluster_lines_into_blocks,
     cluster_words_into_lines, sort_blocks_reading_order, split_lines_at_columns, words_to_text,

--- a/crates/pdfplumber-core/tests/serde_roundtrip.rs
+++ b/crates/pdfplumber-core/tests/serde_roundtrip.rs
@@ -231,6 +231,9 @@ fn test_serde_image() {
         src_height: Some(1080),
         bits_per_component: Some(8),
         color_space: Some("DeviceRGB".to_string()),
+        data: None,
+        filter: None,
+        mime_type: None,
     };
     roundtrip(&img);
 }

--- a/crates/pdfplumber-parse/src/backend.rs
+++ b/crates/pdfplumber-parse/src/backend.rs
@@ -523,6 +523,7 @@ mod tests {
                 height: 300,
                 colorspace: Some("DeviceRGB".to_string()),
                 bits_per_component: Some(8),
+                filter: None,
             });
 
             Ok(())

--- a/crates/pdfplumber-parse/src/handler.rs
+++ b/crates/pdfplumber-parse/src/handler.rs
@@ -91,6 +91,8 @@ pub struct ImageEvent {
     pub colorspace: Option<String>,
     /// Bits per component.
     pub bits_per_component: Option<u32>,
+    /// PDF stream filter name (e.g., "DCTDecode", "FlateDecode").
+    pub filter: Option<String>,
 }
 
 /// Callback handler for content stream interpretation.
@@ -227,6 +229,7 @@ mod tests {
             height: 600,
             colorspace: Some("DeviceRGB".to_string()),
             bits_per_component: Some(8),
+            filter: None,
         }
     }
 
@@ -332,10 +335,21 @@ mod tests {
         let event = ImageEvent {
             colorspace: None,
             bits_per_component: None,
+            filter: None,
             ..sample_image_event()
         };
         assert_eq!(event.colorspace, None);
         assert_eq!(event.bits_per_component, None);
+        assert_eq!(event.filter, None);
+    }
+
+    #[test]
+    fn image_event_with_filter() {
+        let event = ImageEvent {
+            filter: Some("DCTDecode".to_string()),
+            ..sample_image_event()
+        };
+        assert_eq!(event.filter, Some("DCTDecode".to_string()));
     }
 
     // --- ContentHandler with CollectingHandler ---

--- a/crates/pdfplumber-py/src/lib.rs
+++ b/crates/pdfplumber-py/src/lib.rs
@@ -1153,6 +1153,9 @@ mod tests {
             src_height: Some(200),
             bits_per_component: Some(8),
             color_space: Some("DeviceRGB".to_string()),
+            data: None,
+            filter: None,
+            mime_type: None,
         };
         Python::with_gil(|py| {
             let dict_obj = image_to_dict(py, &img).expect("image_to_dict");

--- a/crates/pdfplumber/src/cropped_page.rs
+++ b/crates/pdfplumber/src/cropped_page.rs
@@ -479,6 +479,9 @@ mod tests {
             src_height: Some(100),
             bits_per_component: Some(8),
             color_space: Some("DeviceRGB".to_string()),
+            data: None,
+            filter: None,
+            mime_type: None,
         }
     }
 

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -108,7 +108,7 @@ pub use pdfplumber_core::{
     DedupeOptions, DocumentMetadata, DrawStyle, Edge, EdgeSource, EncodingResolver, ExplicitLines,
     ExtGState, ExtractOptions, ExtractResult, ExtractWarning, FieldType, FillRule, FontEncoding,
     FormField, GraphicsState, HtmlOptions, HtmlRenderer, Hyperlink, Image, ImageContent,
-    ImageFormat, ImageMetadata, Intersection, Line, LineOrientation, MarkdownOptions,
+    ImageFilter, ImageFormat, ImageMetadata, Intersection, Line, LineOrientation, MarkdownOptions,
     MarkdownRenderer, Orientation, PageObject, PaintedPath, Path, PathBuilder, PathSegment,
     PdfError, Point, Rect, RepairOptions, RepairResult, SearchMatch, SearchOptions, Severity,
     SignatureInfo, StandardEncoding, Strategy, StructElement, SvgDebugOptions, SvgOptions,

--- a/crates/pdfplumber/src/page.rs
+++ b/crates/pdfplumber/src/page.rs
@@ -1007,6 +1007,9 @@ mod tests {
             src_height: Some(480),
             bits_per_component: Some(8),
             color_space: Some("DeviceRGB".to_string()),
+            data: None,
+            filter: None,
+            mime_type: None,
         }
     }
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -40,7 +40,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "relatedIssue": 78,
       "notes": "Opt-in to avoid memory bloat. ImageContent struct may already exist — unify or extend."
     },

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -21,6 +21,8 @@ Started: 2026년  3월  1일 일요일 02시 21분 40초 KST
 - `extract_text()` in Page API creates WordOptions from TextOptions and calls `extract_words()` — new options must be forwarded there
 - `WordExtractor::make_word()` is called from 3 places in `extract()` — all must be updated when changing its signature
 - pdfplumber-py tests fail locally due to missing Python 3.11 dylib (pre-existing, not a regression)
+- **Image struct fields**: When adding new Optional fields to Image, also update: image_from_ctm(), test helpers in page.rs/cropped_page.rs, serde_roundtrip.rs, pdfplumber-py test, and any direct Image{} constructors
+- **ImageEvent→Image flow**: Interpreter extracts metadata from stream dict → emits ImageEvent → pdf.rs converts to Image via image_from_ctm(). New image metadata fields must be added to ImageEvent in handler.rs and extracted in interpreter.rs handle_image_xobject()
 
 ---
 
@@ -35,4 +37,28 @@ Started: 2026년  3월  1일 일요일 02시 21분 40초 KST
   - make_word is called from 3 locations in extract() — easy to miss one with simple search-replace
   - Unicode normalization (NFKC/NFKD) already exists in unicode_norm.rs and also expands ligatures, but the dedicated expand_ligatures option is simpler and independent
   - U+FB05 maps to ſt (long s + t), not "st" — preserve the archaic long s character
+---
+
+## 2026-03-01 - US-089
+- **What was implemented**: Added `ImageFilter` enum (8 variants: DCTDecode, FlateDecode, CCITTFaxDecode, JBIG2Decode, JPXDecode, LZWDecode, RunLengthDecode, Raw) with `mime_type()` and `from_pdf_name()` methods. Extended `Image` struct with `data: Option<Vec<u8>>`, `filter: Option<ImageFilter>`, `mime_type: Option<String>`. Added `extract_image_data: bool` (default false) to `ExtractOptions`. Extended `ImageEvent` with `filter: Option<String>` field. Interpreter now extracts filter name from image XObject stream dictionary. In `Pdf::page()`, when `extract_image_data` is enabled, image data is extracted using existing `LopdfBackend::extract_image_content()` and populated into Image struct. Filter and MIME type are set even without data extraction opt-in.
+- **Files changed**:
+  - `crates/pdfplumber-core/src/images.rs` — ImageFilter enum, Image struct new fields, unit tests (10 new)
+  - `crates/pdfplumber-core/src/error.rs` — ExtractOptions.extract_image_data field
+  - `crates/pdfplumber-core/src/lib.rs` — Re-export ImageFilter
+  - `crates/pdfplumber-parse/src/handler.rs` — ImageEvent.filter field, tests
+  - `crates/pdfplumber-parse/src/interpreter.rs` — Extract filter from stream dict in handle_image_xobject
+  - `crates/pdfplumber-parse/src/backend.rs` — Mock backend filter field
+  - `crates/pdfplumber/src/pdf.rs` — Populate filter/mime_type/data in page(), 4 new integration tests
+  - `crates/pdfplumber/src/lib.rs` — Re-export ImageFilter
+  - `crates/pdfplumber/src/page.rs` — Test helper update
+  - `crates/pdfplumber/src/cropped_page.rs` — Test helper update
+  - `crates/pdfplumber-py/src/lib.rs` — Test update
+  - `crates/pdfplumber-core/tests/serde_roundtrip.rs` — Test update
+- **Dependencies added**: None
+- **Learnings for future iterations:**
+  - Image struct has `data: Option<Vec<u8>>` — adding large optional fields to structs is OK when gated behind opt-in options
+  - `ImageFilter` is distinct from `ImageFormat` — filter is the PDF encoding method, format is the output format for extracted data
+  - Adding fields to struct with many existing constructions: use `..Default::default()` pattern in existing code to avoid mass updates
+  - All ExtractOptions constructions already used `..ExtractOptions::default()` — new fields with defaults propagate automatically
+  - Filter info (filter + mime_type) is set regardless of `extract_image_data` — useful for metadata queries without memory cost
 ---


### PR DESCRIPTION
## Summary
- Added `ImageFilter` enum (8 variants mapping to PDF stream filters: DCTDecode, FlateDecode, CCITTFaxDecode, JBIG2Decode, JPXDecode, LZWDecode, RunLengthDecode, Raw) with `mime_type()` and `from_pdf_name()` methods
- Extended `Image` struct with `data: Option<Vec<u8>>`, `filter: Option<ImageFilter>`, `mime_type: Option<String>` fields
- Added `extract_image_data: bool` (default false) to `ExtractOptions` for opt-in image data extraction
- Interpreter now extracts filter name from image XObject stream dictionaries
- Filter and MIME type are populated on all images; raw data only when opted-in

Related: #78

## Test plan
- [x] Unit tests for ImageFilter enum (variants, mime_type, from_pdf_name, clone/copy)
- [x] Unit tests for Image struct with data fields populated and None
- [x] Unit test for ExtractOptions default has extract_image_data: false
- [x] Integration test: image data NOT extracted by default (None)
- [x] Integration test: image data extracted when extract_image_data: true (raw bytes)
- [x] Integration test: JPEG image filter and mime_type set correctly
- [x] Integration test: JPEG data returned as-is when opted-in
- [x] All pre-existing tests pass (1697+ tests, 0 failures)
- [x] cargo fmt, clippy, check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)