### PR TITLE
feat: US-093 - Add merged cell content duplication for tables

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -109,9 +109,9 @@ pub use struct_tree::StructElement;
 pub use svg::{DrawStyle, SvgDebugOptions, SvgOptions, SvgRenderer};
 pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableFinderDebug,
-    TableQuality, TableSettings, cells_to_tables, edges_to_intersections, explicit_lines_to_edges,
-    extract_text_for_cells, intersections_to_cells, join_edge_group, snap_edges,
-    words_to_edges_stream,
+    TableQuality, TableSettings, cells_to_tables, duplicate_merged_content_in_table,
+    edges_to_intersections, explicit_lines_to_edges, extract_text_for_cells,
+    intersections_to_cells, join_edge_group, snap_edges, words_to_edges_stream,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use unicode_norm::{UnicodeNorm, normalize_chars};

--- a/crates/pdfplumber/src/page.rs
+++ b/crates/pdfplumber/src/page.rs
@@ -5,8 +5,9 @@ use pdfplumber_core::{
     HtmlRenderer, Hyperlink, Image, Line, MarkdownOptions, MarkdownRenderer, PageObject, Rect,
     SearchMatch, SearchOptions, StructElement, Table, TableFinder, TableSettings, TextOptions,
     Word, WordExtractor, WordOptions, blocks_to_text, cluster_lines_into_blocks,
-    cluster_words_into_lines, dedupe_chars, derive_edges, extract_text_for_cells, search_chars,
-    sort_blocks_reading_order, split_lines_at_columns, words_to_text,
+    cluster_words_into_lines, dedupe_chars, derive_edges, duplicate_merged_content_in_table,
+    extract_text_for_cells, search_chars, sort_blocks_reading_order, split_lines_at_columns,
+    words_to_text,
 };
 
 use crate::cropped_page::{CroppedPage, FilterMode, PageData, filter_and_build, from_page_data};
@@ -434,6 +435,14 @@ impl Page {
             for col in &mut table.columns {
                 extract_text_for_cells(col, &self.chars);
             }
+        }
+
+        // Duplicate merged cell content if configured
+        if settings.duplicate_merged_content {
+            tables = tables
+                .into_iter()
+                .map(|t| duplicate_merged_content_in_table(&t))
+                .collect();
         }
 
         // Filter by minimum accuracy if configured

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -39,7 +39,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "relatedIssue": 87,
       "notes": "Common request for data pipeline consumers who expect uniform table structures."
     },

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -30,3 +30,18 @@ Started: 2026년  3월  1일 일요일 03시 06분 03초 KST
   - EMC on empty stack is gracefully ignored (no panic)
   - Dictionary parsing in tokenizer was already added in phase 11 (no need to add Dictionary variant again)
 ---
+
+## 2026-03-01 - US-093
+- **What was implemented**: Added `duplicate_merged_content: bool` (default false) to `TableSettings`. Implemented `duplicate_merged_content_in_table()` function that normalizes merged/spanning cells by building a full grid from all unique x/y coordinates, finding the enclosing cell for each grid position, and creating sub-cells with the same text. Integrated into `Page::find_tables()` when the option is enabled.
+- **Files changed**:
+  - `crates/pdfplumber-core/src/table.rs` — `duplicate_merged_content` field on TableSettings, `duplicate_merged_content_in_table()` function, 7 unit tests (horizontal merge, vertical merge, 2x2 merge, no merge unchanged, disabled option, empty table, default false)
+  - `crates/pdfplumber-core/src/lib.rs` — Re-export `duplicate_merged_content_in_table`
+  - `crates/pdfplumber/src/page.rs` — Apply duplication in `find_tables()` when option enabled
+  - `scripts/ralph/prd.json` — marked US-093 as passes: true
+- **Dependencies added**: None
+- **Learnings for future iterations:**
+  - Merged cells in PDF tables create larger cells covering multiple grid positions (internal borders are missing, so intersections don't exist for sub-grid positions)
+  - The grid is determined from all unique x/y coordinates across all cells — this handles any combination of horizontal, vertical, and 2D merges
+  - Center-point containment (with epsilon tolerance) is used to match sub-grid positions to enclosing cells
+  - `float_key()` function already existed for grouping cells into rows/columns — reused for the new function
+---


### PR DESCRIPTION
## Summary
- Add `duplicate_merged_content: bool` field to `TableSettings` (default false)
- Implement `duplicate_merged_content_in_table()` that normalizes merged/spanning cells by building a full grid from all unique x/y coordinates and splitting merged cells into sub-cells with duplicated text
- Wire into `Page::find_tables()` to apply duplication when the option is enabled
- Ensures every row has the same number of columns for data pipeline consumers

## Key Changes
- `table.rs`: `duplicate_merged_content` field on `TableSettings`, `duplicate_merged_content_in_table()` function
- `lib.rs`: Re-export `duplicate_merged_content_in_table`
- `page.rs`: Apply duplication in `find_tables()` when option enabled

## Test Plan
- [x] 7 unit tests: horizontal merge, vertical merge, 2x2 merge, no-merge unchanged, disabled option, empty table, default false
- [x] `cargo test --workspace` passes (excluding pre-existing pdfplumber-py dylib issue)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

Related: #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)