### PR TITLE
feat: US-097 - Document-level resource budgets for production safety

### DIFF
--- a/crates/pdfplumber-parse/src/error.rs
+++ b/crates/pdfplumber-parse/src/error.rs
@@ -105,7 +105,11 @@ mod tests {
 
     #[test]
     fn backend_error_to_pdf_error_core_passthrough() {
-        let original = PdfError::ResourceLimitExceeded("too large".to_string());
+        let original = PdfError::ResourceLimitExceeded {
+            limit_name: "max_input_bytes".to_string(),
+            limit_value: 1024,
+            actual_value: 2048,
+        };
         let backend = BackendError::Core(original.clone());
         let pdf_err: PdfError = backend.into();
         assert_eq!(pdf_err, original);

--- a/crates/pdfplumber-py/src/lib.rs
+++ b/crates/pdfplumber-py/src/lib.rs
@@ -34,7 +34,13 @@ fn to_py_err(e: PdfError) -> PyErr {
         PdfError::IoError(msg) => PdfIoError::new_err(msg),
         PdfError::FontError(msg) => PdfFontError::new_err(msg),
         PdfError::InterpreterError(msg) => PdfInterpreterError::new_err(msg),
-        PdfError::ResourceLimitExceeded(msg) => PdfResourceLimitError::new_err(msg),
+        PdfError::ResourceLimitExceeded {
+            limit_name,
+            limit_value,
+            actual_value,
+        } => PdfResourceLimitError::new_err(format!(
+            "{limit_name} (limit: {limit_value}, actual: {actual_value})"
+        )),
         PdfError::PasswordRequired => {
             PdfPasswordRequired::new_err("PDF is encrypted and requires a password")
         }
@@ -977,7 +983,11 @@ mod tests {
 
     #[test]
     fn test_to_py_err_resource_limit() {
-        let err = to_py_err(PdfError::ResourceLimitExceeded("too many".to_string()));
+        let err = to_py_err(PdfError::ResourceLimitExceeded {
+            limit_name: "max_pages".to_string(),
+            limit_value: 10,
+            actual_value: 20,
+        });
         Python::with_gil(|py| {
             assert!(err.is_instance_of::<PdfResourceLimitError>(py));
         });

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -40,7 +40,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "relatedIssue": 103,
       "notes": "Critical for production pipelines processing untrusted PDFs."
     },

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -13,6 +13,10 @@ Started: 2026년  3월  1일 일요일 03시 06분 03초 KST
 - serde support uses conditional derive: `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]`
 - All ExtractOptions struct literals in tests use `..ExtractOptions::default()` spread, so adding new fields with defaults is backward-compatible
 - pdfplumber-py tests fail in local env due to missing libpython3.11.dylib — pre-existing issue, skip with `-p` flags
+- PdfError::ResourceLimitExceeded is a struct variant: `{ limit_name: String, limit_value: usize, actual_value: usize }`
+- Document-level budgets are `Option<usize>` fields on ExtractOptions (None=no limit for backward compat)
+- max_input_bytes checked in Pdf::open before parsing; max_pages checked in from_doc after page_count
+- Accumulated counters (total_objects, total_image_bytes) use AtomicUsize in Pdf struct for thread safety with pages_parallel()
 
 ---
 
@@ -61,4 +65,26 @@ Started: 2026년  3월  1일 일요일 03시 06분 03초 KST
   - Existing constructors (new, on_page, with_context, with_operator_context) default to Other code
   - Use set_code() builder pattern to override after construction
   - Existing tests check .description field, not Display output, so Display format changes don't break them
+---
+
+## 2026-03-01 - US-097 (Phase 13)
+- Implemented document-level resource budgets for production safety
+- PdfError::ResourceLimitExceeded changed from `(String)` to struct variant `{ limit_name, limit_value, actual_value }`
+- ExtractOptions gained 4 new `Option<usize>` fields: max_input_bytes, max_pages, max_total_image_bytes, max_total_objects
+- All default to None (no limit) for backward compatibility
+- max_input_bytes: checked in Pdf::open() before parsing
+- max_pages: checked in from_doc() after getting page_count
+- max_total_objects: AtomicUsize counter in Pdf, checked after each page() extraction (chars+lines+rects+curves+images)
+- max_total_image_bytes: AtomicUsize counter in Pdf, checked after each page() extraction (sum of image data bytes)
+- 10 new tests: 7 integration (rejects/allows/disabled), 3 unit (defaults, custom, clone)
+- Files changed:
+  - crates/pdfplumber-core/src/error.rs (struct variant + new fields + tests)
+  - crates/pdfplumber/src/pdf.rs (budget checks + AtomicUsize counters)
+  - crates/pdfplumber/tests/pdf_integration.rs (7 integration tests)
+  - crates/pdfplumber-parse/src/error.rs (updated test for struct variant)
+  - crates/pdfplumber-py/src/lib.rs (updated match arm + test)
+- **Learnings for future iterations:**
+  - Pdf doesn't implement Debug, so can't use unwrap_err() in tests — use match patterns instead
+  - AtomicUsize with Relaxed ordering is sufficient for counters since exact accuracy isn't critical
+  - fetch_add returns the *previous* value, so add page_object_count to get the new total
 ---


### PR DESCRIPTION
## Summary
- Added document-level resource budgets (`max_input_bytes`, `max_pages`, `max_total_image_bytes`, `max_total_objects`) to `ExtractOptions` for production safety when processing untrusted PDFs
- Changed `PdfError::ResourceLimitExceeded` from `(String)` to a struct variant with `limit_name`, `limit_value`, and `actual_value` fields for machine-readable error reporting
- All limits default to `None` (no limit) for backward compatibility

## Key Changes
- `ExtractOptions`: 4 new `Option<usize>` fields with `None` defaults
- `PdfError::ResourceLimitExceeded`: struct variant with structured fields
- `Pdf::open()`: checks `max_input_bytes` before parsing
- `Pdf::from_doc()`: checks `max_pages` after determining page count
- `Pdf::page()`: accumulates and checks `max_total_objects` and `max_total_image_bytes` using `AtomicUsize` counters (thread-safe for `pages_parallel()`)

## Test plan
- [x] 7 integration tests: rejects oversized PDF, rejects over page limit, allows within limits, disabled by default, total objects limit
- [x] 3 unit tests: defaults are None, custom values, clone/eq
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test -p pdfplumber-core -p pdfplumber-parse -p pdfplumber -p pdfplumber-cli -p pdfplumber-wasm` passes

Related: #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)