### PR TITLE
feat: US-105 - Verify accuracy benchmark improvement for generated PDFs

### DIFF
--- a/crates/pdfplumber/tests/accuracy_benchmark.rs
+++ b/crates/pdfplumber/tests/accuracy_benchmark.rs
@@ -7,10 +7,9 @@
 //! - Chars/Words: Precision, Recall, F1 (nearest-neighbor text+bbox matching)
 //! - Table cell text match rate
 //!
-//! Current baseline thresholds reflect measured accuracy. PRD targets (chars/words
-//! F1 >= 0.95, lattice table >= 0.90) are documented in comments alongside each
-//! assertion. As the parser improves (font metrics, coordinate handling), thresholds
-//! should be raised toward PRD targets.
+//! With standard font width fallback (US-103/US-104), most tests now meet or exceed
+//! PRD targets (chars/words F1 >= 0.95, lattice table >= 0.90). Remaining gaps are
+//! in multi_font (non-standard fonts) and rotated_pages (coordinate transforms).
 
 use pdfplumber::{Pdf, TableSettings, WordOptions};
 use serde::Deserialize;
@@ -84,8 +83,8 @@ struct F1Result {
 }
 
 /// Coordinate tolerance for matching (in points).
-/// fpdf2-generated PDFs have ~7pt fixed-width chars vs proportional golden widths,
-/// causing cumulative x-drift. Real-world PDFs have much tighter coordinate agreement.
+/// With standard font fallback, coordinate agreement is typically sub-point.
+/// Tolerance of 2.0 provides margin for minor rounding differences.
 const COORD_TOLERANCE: f64 = 2.0;
 
 /// Compute bbox center distance between two bboxes.
@@ -488,11 +487,9 @@ fn print_table_summary(name: &str, results: &[(usize, usize)]) {
 // ---------------------------------------------------------------------------
 // Generated fixture tests (tests/fixtures/generated/)
 //
-// Note: fpdf2-generated PDFs use fixed character widths in content streams.
-// Python pdfplumber resolves proportional widths via font metrics, while our
-// Rust parser currently uses the content-stream widths. This causes cumulative
-// x-coordinate drift, lowering bbox-based F1 scores for generated PDFs.
-// Baseline thresholds reflect current measured accuracy.
+// fpdf2-generated PDFs use standard Type1 fonts. With the standard font width
+// fallback (US-103/US-104), proportional widths are correctly resolved, bringing
+// most generated PDF scores to F1=1.0.
 // PRD target: chars/words F1 >= 0.95
 // ---------------------------------------------------------------------------
 
@@ -501,9 +498,9 @@ fn accuracy_basic_text() {
     let (cf1, wf1) = benchmark_pdf("generated", "basic_text.pdf", "basic_text")
         .expect("basic_text.pdf should parse");
     print_text_summary("basic_text.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.08, words F1~0.02 (font metrics gap)
-    // PRD target: >= 0.95
-    assert!(cf1.f1 >= 0.05, "basic_text chars F1 {:.3} < 0.05", cf1.f1);
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
+    assert!(cf1.f1 >= 0.95, "basic_text chars F1 {:.3} < 0.95", cf1.f1);
+    assert!(wf1.f1 >= 0.95, "basic_text words F1 {:.3} < 0.95", wf1.f1);
 }
 
 #[test]
@@ -511,9 +508,9 @@ fn accuracy_multicolumn() {
     let (cf1, wf1) = benchmark_pdf("generated", "multicolumn.pdf", "multicolumn")
         .expect("multicolumn.pdf should parse");
     print_text_summary("multicolumn.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.22
-    // PRD target: >= 0.95
-    assert!(cf1.f1 >= 0.15, "multicolumn chars F1 {:.3} < 0.15", cf1.f1);
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
+    assert!(cf1.f1 >= 0.95, "multicolumn chars F1 {:.3} < 0.95", cf1.f1);
+    assert!(wf1.f1 >= 0.95, "multicolumn words F1 {:.3} < 0.95", wf1.f1);
 }
 
 #[test]
@@ -521,12 +518,16 @@ fn accuracy_table_lattice() {
     let (cf1, wf1) = benchmark_pdf("generated", "table_lattice.pdf", "table_lattice")
         .expect("table_lattice.pdf should parse");
     print_text_summary("table_lattice.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.53
-    // PRD target: >= 0.95
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
     assert!(
-        cf1.f1 >= 0.40,
-        "table_lattice chars F1 {:.3} < 0.40",
+        cf1.f1 >= 0.95,
+        "table_lattice chars F1 {:.3} < 0.95",
         cf1.f1
+    );
+    assert!(
+        wf1.f1 >= 0.95,
+        "table_lattice words F1 {:.3} < 0.95",
+        wf1.f1
     );
 
     // Table cell accuracy
@@ -540,12 +541,16 @@ fn accuracy_table_borderless() {
     let (cf1, wf1) = benchmark_pdf("generated", "table_borderless.pdf", "table_borderless")
         .expect("table_borderless.pdf should parse");
     print_text_summary("table_borderless.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.53
-    // PRD target: >= 0.95
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
     assert!(
-        cf1.f1 >= 0.40,
-        "table_borderless chars F1 {:.3} < 0.40",
+        cf1.f1 >= 0.95,
+        "table_borderless chars F1 {:.3} < 0.95",
         cf1.f1
+    );
+    assert!(
+        wf1.f1 >= 0.95,
+        "table_borderless words F1 {:.3} < 0.95",
+        wf1.f1
     );
 }
 
@@ -554,12 +559,16 @@ fn accuracy_table_merged_cells() {
     let (cf1, wf1) = benchmark_pdf("generated", "table_merged_cells.pdf", "table_merged_cells")
         .expect("table_merged_cells.pdf should parse");
     print_text_summary("table_merged_cells.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.71, words F1~0.82
-    // PRD target: >= 0.95
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
     assert!(
-        cf1.f1 >= 0.60,
-        "table_merged_cells chars F1 {:.3} < 0.60",
+        cf1.f1 >= 0.95,
+        "table_merged_cells chars F1 {:.3} < 0.95",
         cf1.f1
+    );
+    assert!(
+        wf1.f1 >= 0.95,
+        "table_merged_cells words F1 {:.3} < 0.95",
+        wf1.f1
     );
 
     // Table cell accuracy
@@ -574,9 +583,11 @@ fn accuracy_multi_font() {
     let (cf1, wf1) = benchmark_pdf("generated", "multi_font.pdf", "multi_font")
         .expect("multi_font.pdf should parse");
     print_text_summary("multi_font.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.09
-    // PRD target: >= 0.95
-    assert!(cf1.f1 >= 0.05, "multi_font chars F1 {:.3} < 0.05", cf1.f1);
+    // Measured: chars F1=0.588, words F1=0.595 (improved from ~0.09)
+    // multi_font uses non-standard fonts beyond the 14 standard Type1 fonts,
+    // so standard font fallback only partially helps. PRD target: >= 0.95
+    assert!(cf1.f1 >= 0.55, "multi_font chars F1 {:.3} < 0.55", cf1.f1);
+    assert!(wf1.f1 >= 0.55, "multi_font words F1 {:.3} < 0.55", wf1.f1);
 }
 
 #[test]
@@ -584,9 +595,9 @@ fn accuracy_rotated_pages() {
     let (cf1, wf1) = benchmark_pdf("generated", "rotated_pages.pdf", "rotated_pages")
         .expect("rotated_pages.pdf should parse");
     print_text_summary("rotated_pages.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.01 (rotation coordinate transform differences)
-    // PRD target: >= 0.95
-    // No assertion — rotation handling is a known gap
+    // Measured: chars F1=0.241 (improved from ~0.01)
+    // Rotation coordinate transform differences remain a known gap. PRD target: >= 0.95
+    // No assertion — rotation handling needs dedicated fix
 }
 
 #[test]
@@ -594,9 +605,9 @@ fn accuracy_cjk_mixed() {
     let (cf1, wf1) = benchmark_pdf("generated", "cjk_mixed.pdf", "cjk_mixed")
         .expect("cjk_mixed.pdf should parse");
     print_text_summary("cjk_mixed.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.08
-    // PRD target: >= 0.95
-    assert!(cf1.f1 >= 0.05, "cjk_mixed chars F1 {:.3} < 0.05", cf1.f1);
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
+    assert!(cf1.f1 >= 0.95, "cjk_mixed chars F1 {:.3} < 0.95", cf1.f1);
+    assert!(wf1.f1 >= 0.95, "cjk_mixed words F1 {:.3} < 0.95", wf1.f1);
 }
 
 #[test]
@@ -604,12 +615,16 @@ fn accuracy_long_document() {
     let (cf1, wf1) = benchmark_pdf("generated", "long_document.pdf", "long_document")
         .expect("long_document.pdf should parse");
     print_text_summary("long_document.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.17
-    // PRD target: >= 0.95
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
     assert!(
-        cf1.f1 >= 0.10,
-        "long_document chars F1 {:.3} < 0.10",
+        cf1.f1 >= 0.95,
+        "long_document chars F1 {:.3} < 0.95",
         cf1.f1
+    );
+    assert!(
+        wf1.f1 >= 0.95,
+        "long_document words F1 {:.3} < 0.95",
+        wf1.f1
     );
 }
 
@@ -618,20 +633,25 @@ fn accuracy_annotations_links() {
     let (cf1, wf1) = benchmark_pdf("generated", "annotations_links.pdf", "annotations_links")
         .expect("annotations_links.pdf should parse");
     print_text_summary("annotations_links.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.12
-    // PRD target: >= 0.95
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
     assert!(
-        cf1.f1 >= 0.05,
-        "annotations_links chars F1 {:.3} < 0.05",
+        cf1.f1 >= 0.95,
+        "annotations_links chars F1 {:.3} < 0.95",
         cf1.f1
+    );
+    assert!(
+        wf1.f1 >= 0.95,
+        "annotations_links words F1 {:.3} < 0.95",
+        wf1.f1
     );
 }
 
 // ---------------------------------------------------------------------------
 // Downloaded fixture tests (tests/fixtures/downloaded/)
 //
-// Real-world PDFs with embedded font metrics. These typically have much higher
-// accuracy than fpdf2-generated fixtures because font widths resolve correctly.
+// Real-world PDFs. With standard font fallback, these now achieve near-perfect
+// accuracy. Embedded font metrics continue to work correctly alongside the
+// standard font fallback.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -643,16 +663,15 @@ fn accuracy_nics_firearm_checks() {
     )
     .expect("nics-firearm-checks.pdf should parse");
     print_text_summary("nics-firearm-checks.pdf", &cf1, &wf1);
-    // Baseline: chars F1~0.89, words F1~0.92 — close to PRD target
-    // PRD target: chars/words F1 >= 0.95
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
     assert!(
-        cf1.f1 >= 0.80,
-        "nics-firearm-checks chars F1 {:.3} < 0.80",
+        cf1.f1 >= 0.95,
+        "nics-firearm-checks chars F1 {:.3} < 0.95",
         cf1.f1
     );
     assert!(
-        wf1.f1 >= 0.80,
-        "nics-firearm-checks words F1 {:.3} < 0.80",
+        wf1.f1 >= 0.95,
+        "nics-firearm-checks words F1 {:.3} < 0.95",
         wf1.f1
     );
 
@@ -667,27 +686,25 @@ fn accuracy_nics_firearm_checks() {
 
 #[test]
 fn accuracy_scotus_transcript() {
-    // This PDF currently fails to parse (content stream issue).
-    // Test documents the failure and skips gracefully.
-    let result = benchmark_pdf(
+    // Measured: chars F1=0.999, words F1=1.000
+    let (cf1, wf1) = benchmark_pdf(
         "downloaded",
         "scotus-transcript-p1.pdf",
         "scotus-transcript-p1",
+    )
+    .expect("scotus-transcript-p1.pdf should parse");
+    print_text_summary("scotus-transcript-p1.pdf", &cf1, &wf1);
+    // PRD target: chars/words F1 >= 0.95
+    assert!(
+        cf1.f1 >= 0.95,
+        "scotus-transcript chars F1 {:.3} < 0.95",
+        cf1.f1
     );
-    match result {
-        Some((cf1, wf1)) => {
-            print_text_summary("scotus-transcript-p1.pdf", &cf1, &wf1);
-            // PRD target: chars/words F1 >= 0.95
-            assert!(
-                cf1.f1 >= 0.50,
-                "scotus-transcript chars F1 {:.3} < 0.50",
-                cf1.f1
-            );
-        }
-        None => {
-            println!("scotus-transcript-p1.pdf: parse not yet supported, skipping assertions");
-        }
-    }
+    assert!(
+        wf1.f1 >= 0.95,
+        "scotus-transcript words F1 {:.3} < 0.95",
+        wf1.f1
+    );
 }
 
 #[test]
@@ -695,10 +712,9 @@ fn accuracy_pdffill_demo() {
     let (cf1, wf1) = benchmark_pdf("downloaded", "pdffill-demo.pdf", "pdffill-demo")
         .expect("pdffill-demo.pdf should parse");
     print_text_summary("pdffill-demo.pdf", &cf1, &wf1);
-    // Baseline: chars F1=1.000, words F1=0.958 — meets PRD target
-    // PRD target: chars/words F1 >= 0.95
+    // Measured: chars F1=1.000, words F1=1.000 (PRD target: >= 0.95)
     assert!(cf1.f1 >= 0.95, "pdffill-demo chars F1 {:.3} < 0.95", cf1.f1);
-    assert!(wf1.f1 >= 0.90, "pdffill-demo words F1 {:.3} < 0.90", wf1.f1);
+    assert!(wf1.f1 >= 0.95, "pdffill-demo words F1 {:.3} < 0.95", wf1.f1);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -57,7 +57,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": "Accuracy benchmark test file: crates/pdfplumber/tests/accuracy_benchmark.rs (on feat/accuracy-benchmark branch, PR #125). Golden data in tests/fixtures/golden/. Current baselines: basic_text char=0.05, multicolumn char=0.10. These should jump to near 1.0."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -11,6 +11,7 @@ Started: 2026년  3월  1일 일요일 04시 55분 12초 KST
 - Standard font fallback: `lookup_standard_font(font_dict)` in `font_metrics.rs` — reads `/BaseFont`, strips subset prefix, looks up standard widths
 - When standard font matched: widths cover codes 0-255, `first_char=0`, `last_char=255`; descriptor values override standard defaults
 - pdfplumber-py tests SIGABRT on macOS (pre-existing, unrelated to standard font work)
+- Accuracy benchmark: `crates/pdfplumber/tests/accuracy_benchmark.rs`, golden data in `tests/fixtures/golden/`; aggregate F1: chars=0.991, words=0.994
 
 ---
 
@@ -41,4 +42,25 @@ Started: 2026년  3월  1일 일요일 04시 55분 12초 KST
   - Standard font fallback improves text grouping quality — proportional widths produce correct x-positions for word boundary detection
   - `lopdf::Object::as_name()` returns `&[u8]`, needs `std::str::from_utf8()` conversion
   - Existing tests may break when behavior changes are intentional improvements — update assertions to match new correct behavior
+---
+
+## 2026-03-01 - US-105
+- Ran accuracy benchmark after standard font integration — dramatic improvements across all generated PDFs
+- Updated thresholds in `crates/pdfplumber/tests/accuracy_benchmark.rs` to reflect new baselines
+- Results summary:
+  - basic_text: F1 0.05→1.000, multicolumn: 0.15→1.000, table_lattice: 0.40→1.000
+  - table_borderless: 0.40→1.000, table_merged_cells: 0.60→1.000, cjk_mixed: 0.05→1.000
+  - long_document: 0.10→1.000, annotations_links: 0.05→1.000
+  - multi_font: 0.05→0.588 (non-standard fonts), rotated_pages: 0.01→0.241 (rotation gap)
+  - nics-firearm-checks: 0.80→1.000, scotus-transcript: now parses (F1=0.999), pdffill-demo: 1.000
+  - Aggregate: chars F1=0.991, words F1=0.994 (exceeds PRD target of 0.95)
+- 10/12 PDFs now meet PRD char/word F1>=0.95 target; remaining gaps are multi_font and rotated_pages
+- scotus-transcript now parses successfully — updated test from graceful skip to assertion
+- Files changed: `crates/pdfplumber/tests/accuracy_benchmark.rs`, `scripts/ralph/prd.json`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - Standard font width tables are the single biggest accuracy lever for generated PDFs
+  - multi_font.pdf uses non-standard fonts — needs embedded font metrics or extended font tables
+  - Rotation coordinate transforms remain a separate problem from font metrics
+  - scotus-transcript parsing was fixed at some point — always re-test known failures
 ---


### PR DESCRIPTION
## Summary
- Updated accuracy benchmark thresholds after standard font width integration (US-103/US-104)
- 8/9 generated PDFs now achieve chars/words F1=1.000 (previously 0.01-0.71)
- All 3 real-world PDFs achieve F1>=0.999 (previously 0.89-1.000)
- Aggregate scores: chars F1=0.991, words F1=0.994, exceeding PRD target of 0.95
- scotus-transcript-p1.pdf now parses successfully — upgraded from graceful skip to assertion

## Test plan
- [x] Run `cargo test -p pdfplumber --test accuracy_benchmark -- --nocapture` — all 14 tests pass
- [x] Verify generated PDF F1 scores improved significantly (most >0.95)
- [x] Verify real-world PDF scores unchanged or improved
- [x] Run `cargo fmt --all -- --check` — passes
- [x] Run `cargo clippy --workspace -- -D warnings` — passes
- [x] Run `cargo test --workspace --exclude pdfplumber-py` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)