### PR TITLE
feat: implement grid completion for lattice table detection (US-107)

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -125,7 +125,7 @@ pub use svg::{DrawStyle, SvgDebugOptions, SvgOptions, SvgRenderer};
 pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableFinderDebug,
     TableQuality, TableSettings, cells_to_tables, duplicate_merged_content_in_table,
-    edges_to_intersections, explicit_lines_to_edges, extract_text_for_cells,
+    edges_to_cells, edges_to_intersections, explicit_lines_to_edges, extract_text_for_cells,
     intersections_to_cells, join_edge_group, snap_edges, words_to_edges_stream,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -117,7 +117,7 @@ pub use pdfplumber_core::{
     TableQuality, TableSettings, TextBlock, TextDirection, TextLine, TextOptions, UnicodeNorm,
     ValidationIssue, Word, WordExtractor, WordOptions, blocks_to_text, cells_to_tables,
     cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, detect_columns,
-    edge_from_curve, edge_from_line, edges_from_rect, edges_to_intersections,
+    edge_from_curve, edge_from_line, edges_from_rect, edges_to_cells, edges_to_intersections,
     explicit_lines_to_edges, export_image_set, extract_shapes, extract_text_for_cells,
     image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
     sort_blocks_column_order, sort_blocks_reading_order, split_lines_at_columns,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -35,7 +35,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "Key function: intersections_to_cells in crates/pdfplumber-core/src/table.rs line 455. The function currently uses has_point() for a strict 4-corner check. The edges (after snap+join) are available in the TableFinder, so they can be passed to the cell detection step. Consider adding a new function like edges_to_cells() that takes both intersections AND edges, or modifying intersections_to_cells to accept edges for coverage checking."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -33,3 +33,19 @@ Started: 2026년  3월  1일 일요일 05시 26분 49초 KST
 - 26 unique x-positions and 18 unique y-positions after snapping.
 - The "2 cols" in Rust output is because most y-pairs only have 2 corners matching at the outer borders (x=33.1 and x=975.3).
 ---
+
+## 2026-03-01 - US-107
+- Implemented `edges_to_cells` function with two-phase grid completion in `crates/pdfplumber-core/src/table.rs`
+- Phase 1: strict 4-edge coverage creates core cells, records established column boundaries
+- Phase 2: grid completion — for remaining positions, if H edges span [x0, x1] at top AND bottom, AND x0/x1 are established column boundaries from Phase 1, create the cell
+- Updated `find_tables()` and `find_tables_debug()` to call `edges_to_cells` instead of `intersections_to_cells`
+- Exported `edges_to_cells` from core and facade crates
+- Wrote 8 unit tests for `edges_to_cells` (complete grid, partial intersections, empty cases, tolerance, etc.)
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`, `scripts/ralph/prd.json`
+
+### Results:
+- nics table accuracy: 6.8% → 87.5% (372/425 cells match positionally)
+- Rust table dimensions: now 17 rows x 25 cols = 425 cells (matches golden exactly)
+- 53 unmatched cells are text extraction differences, not structural
+- All existing tests pass (0 regressions)
+---


### PR DESCRIPTION
## Summary
- Add `edges_to_cells()` function with two-phase grid completion in `crates/pdfplumber-core/src/table.rs`
- Phase 1: strict 4-edge coverage creates core cells and records established column boundaries
- Phase 2: grid completion — for remaining grid positions, if horizontal edges span cell width at both top and bottom y, and column boundaries are established by Phase 1 cells, create the cell
- Update `find_tables()` and `find_tables_debug()` to call `edges_to_cells` instead of `intersections_to_cells`
- Export `edges_to_cells` from core and facade crates
- nics-background-checks table accuracy improved from **6.8% → 87.5%** (372/425 cells match positionally)
- Rust now produces exact 17 rows × 25 cols = 425 cells matching Python pdfplumber golden data

## Test plan
- [x] 8 new unit tests for `edges_to_cells` (complete grid, partial intersections, empty cases, tolerance, single-row, missing vertical)
- [x] All existing tests pass — 0 regressions
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (excluding pdfplumber-py/wasm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)