### PR TITLE
feat: normalize merged table cells for 100% accuracy (US-108)

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -126,7 +126,8 @@ pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableFinderDebug,
     TableQuality, TableSettings, cells_to_tables, duplicate_merged_content_in_table,
     edges_to_cells, edges_to_intersections, explicit_lines_to_edges, extract_text_for_cells,
-    intersections_to_cells, join_edge_group, snap_edges, words_to_edges_stream,
+    intersections_to_cells, join_edge_group, normalize_table_columns, snap_edges,
+    words_to_edges_stream,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use unicode_norm::{UnicodeNorm, normalize_chars};

--- a/crates/pdfplumber/src/cropped_page.rs
+++ b/crates/pdfplumber/src/cropped_page.rs
@@ -8,8 +8,8 @@ use pdfplumber_core::{
     BBox, Char, ColumnMode, Curve, DedupeOptions, Edge, Image, Line, PageObject, Rect, Table,
     TableFinder, TableSettings, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text,
     cluster_lines_into_blocks, cluster_words_into_lines, dedupe_chars, derive_edges,
-    detect_columns, extract_text_for_cells, sort_blocks_column_order, sort_blocks_reading_order,
-    split_lines_at_columns, words_to_text,
+    detect_columns, extract_text_for_cells, normalize_table_columns, sort_blocks_column_order,
+    sort_blocks_reading_order, split_lines_at_columns, words_to_text,
 };
 
 /// A spatially filtered view of a PDF page.
@@ -134,6 +134,12 @@ impl CroppedPage {
                 extract_text_for_cells(col, &self.chars);
             }
         }
+
+        // Normalize merged cells: split wide cells into uniform grid columns
+        tables = tables
+            .into_iter()
+            .map(|t| normalize_table_columns(&t))
+            .collect();
 
         tables
     }

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -119,9 +119,9 @@ pub use pdfplumber_core::{
     cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, detect_columns,
     edge_from_curve, edge_from_line, edges_from_rect, edges_to_cells, edges_to_intersections,
     explicit_lines_to_edges, export_image_set, extract_shapes, extract_text_for_cells,
-    image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text, join_edge_group, snap_edges,
-    sort_blocks_column_order, sort_blocks_reading_order, split_lines_at_columns,
-    words_to_edges_stream, words_to_text,
+    image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text, join_edge_group,
+    normalize_table_columns, snap_edges, sort_blocks_column_order, sort_blocks_reading_order,
+    split_lines_at_columns, words_to_edges_stream, words_to_text,
 };
 pub use pdfplumber_parse::{
     self, CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, LopdfPage,

--- a/crates/pdfplumber/tests/cross_validation.rs
+++ b/crates/pdfplumber/tests/cross_validation.rs
@@ -6,7 +6,7 @@
 //!
 //! All char/word/line/rect metrics at or above PRD targets (95%+).
 //! - **scotus-transcript**: 1 char gap (synthetic `\n` from Python layout analysis).
-//! - **nics-background-checks tables**: Table cell accuracy ~6.8% (needs investigation).
+//! - **nics-background-checks tables**: Table cell accuracy 100% after grid completion fix.
 
 #![allow(dead_code)]
 
@@ -592,7 +592,7 @@ fn cross_validate_scotus_transcript() {
 }
 
 /// nics-background-checks-2015-11.pdf: complex lattice table.
-/// Chars/words/lines/rects at 100%. Table accuracy ~6.8% (needs investigation).
+/// All metrics at 100% including table cell accuracy.
 #[test]
 fn cross_validate_nics_background_checks() {
     let result = validate_pdf("nics-background-checks-2015-11.pdf");
@@ -618,6 +618,12 @@ fn cross_validate_nics_background_checks() {
         result.total_rect_rate() >= 1.0,
         "rect rate {:.1}% < 100%",
         result.total_rect_rate() * 100.0,
+    );
+    assert!(
+        result.total_table_rate() >= TABLE_THRESHOLD,
+        "table rate {:.1}% < {:.1}%",
+        result.total_table_rate() * 100.0,
+        TABLE_THRESHOLD * 100.0,
     );
 }
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -52,8 +52,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": "Cross-validation test file: crates/pdfplumber/tests/cross_validation.rs. Golden data: crates/pdfplumber/tests/fixtures/golden/nics-background-checks-2015-11.json. Current status: chars=100%, words=100%, lines=100%, rects=100%, tables=6.8%."
+      "passes": true,
+      "notes": "Cross-validation test file: crates/pdfplumber/tests/cross_validation.rs. Golden data: crates/pdfplumber/tests/fixtures/golden/nics-background-checks-2015-11.json. Current status: chars=100%, words=100%, lines=100%, rects=100%, tables=100%."
     }
   ]
 }

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -49,3 +49,19 @@ Started: 2026년  3월  1일 일요일 05시 26분 49초 KST
 - 53 unmatched cells are text extraction differences, not structural
 - All existing tests pass (0 regressions)
 ---
+
+## 2026-03-01 - US-108
+- Modified Phase 2 in `edges_to_cells` to create merged cells between V-edge boundaries instead of narrow cells at every column
+- Added `normalize_table_columns` function: splits merged cells into uniform grid columns with text in first sub-cell only
+- Called `normalize_table_columns` in `Page::find_tables` and `CroppedPage::find_tables` after text extraction
+- Exported `normalize_table_columns` from core and facade crates
+- Updated `cross_validation.rs` to assert table rate >= TABLE_THRESHOLD (0.90) for nics-background-checks
+- Removed "needs investigation" comments
+- Wrote 3 unit tests for `normalize_table_columns` (uniform grid, merged header, empty table)
+- Files changed: `crates/pdfplumber-core/src/table.rs`, `crates/pdfplumber-core/src/lib.rs`, `crates/pdfplumber/src/lib.rs`, `crates/pdfplumber/src/page.rs`, `crates/pdfplumber/src/cropped_page.rs`, `crates/pdfplumber/tests/cross_validation.rs`, `scripts/ralph/prd.json`
+
+### Results:
+- nics table accuracy: 87.5% → 100% (425/425 cells match)
+- All other cross-validation metrics unchanged: chars=100%, words=100%, lines=100%, rects=100%
+- All existing tests pass (0 regressions)
+---


### PR DESCRIPTION
## Summary
- Modify Phase 2 in `edges_to_cells` to create **merged cells** between vertical edge boundaries (instead of narrow cells at every column position), matching Python pdfplumber's behavior for merged header/footer rows
- Add `normalize_table_columns()` function that splits merged cells into uniform grid columns with text placed only in the first sub-cell (top-left corner of each merged group)
- Call `normalize_table_columns` in `Page::find_tables` and `CroppedPage::find_tables` after text extraction
- nics-background-checks table cell accuracy improved from **87.5% → 100%** (425/425 cells match golden data)
- Assert table rate >= 90% in cross-validation test, removing "needs investigation" comments

## Test plan
- [x] 3 new unit tests for `normalize_table_columns` (uniform grid, merged header, empty table)
- [x] 8 existing `edges_to_cells` unit tests still pass
- [x] All 5 cross-validation tests pass (all PDFs at 100%)
- [x] All existing tests pass — 0 regressions
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (excluding pdfplumber-py/wasm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)