### PR TITLE
feat: US-153-1 - Change UnicodeNorm default to Nfc and add for_llm() preset

### DIFF
--- a/crates/pdfplumber-core/src/error.rs
+++ b/crates/pdfplumber-core/src/error.rs
@@ -304,7 +304,7 @@ pub struct ExtractOptions {
     pub max_stream_bytes: usize,
     /// Whether to collect warnings during extraction (default: true).
     pub collect_warnings: bool,
-    /// Unicode normalization form to apply to extracted character text (default: None).
+    /// Unicode normalization form to apply to extracted character text (default: Nfc).
     pub unicode_norm: UnicodeNorm,
     /// Whether to extract image stream data into Image structs (default: false).
     ///
@@ -331,13 +331,26 @@ impl Default for ExtractOptions {
             max_objects_per_page: 100_000,
             max_stream_bytes: 100 * 1024 * 1024,
             collect_warnings: true,
-            unicode_norm: UnicodeNorm::None,
+            unicode_norm: UnicodeNorm::Nfc,
             extract_image_data: false,
             strict_mode: false,
             max_input_bytes: None,
             max_pages: None,
             max_total_image_bytes: None,
             max_total_objects: None,
+        }
+    }
+}
+
+impl ExtractOptions {
+    /// Create options optimized for LLM consumption.
+    ///
+    /// Returns options with NFC Unicode normalization enabled, which ensures
+    /// consistent text representation for language model processing.
+    pub fn for_llm() -> Self {
+        Self {
+            unicode_norm: UnicodeNorm::Nfc,
+            ..Self::default()
         }
     }
 }
@@ -596,12 +609,22 @@ mod tests {
         assert_eq!(opts.max_objects_per_page, 100_000);
         assert_eq!(opts.max_stream_bytes, 100 * 1024 * 1024);
         assert!(opts.collect_warnings);
-        assert_eq!(opts.unicode_norm, UnicodeNorm::None);
+        assert_eq!(opts.unicode_norm, UnicodeNorm::Nfc);
         assert!(!opts.extract_image_data);
         assert!(opts.max_input_bytes.is_none());
         assert!(opts.max_pages.is_none());
         assert!(opts.max_total_image_bytes.is_none());
         assert!(opts.max_total_objects.is_none());
+    }
+
+    #[test]
+    fn extract_options_for_llm() {
+        let opts = ExtractOptions::for_llm();
+        assert_eq!(opts.unicode_norm, UnicodeNorm::Nfc);
+        assert_eq!(opts.max_recursion_depth, 10);
+        assert_eq!(opts.max_objects_per_page, 100_000);
+        assert_eq!(opts.max_stream_bytes, 100 * 1024 * 1024);
+        assert!(opts.collect_warnings);
     }
 
     #[test]

--- a/crates/pdfplumber-core/src/unicode_norm.rs
+++ b/crates/pdfplumber-core/src/unicode_norm.rs
@@ -15,10 +15,10 @@ use crate::text::Char;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UnicodeNorm {
-    /// No normalization (default).
-    #[default]
+    /// No normalization.
     None,
-    /// Canonical Decomposition, followed by Canonical Composition (NFC).
+    /// Canonical Decomposition, followed by Canonical Composition (NFC) (default).
+    #[default]
     Nfc,
     /// Canonical Decomposition (NFD).
     Nfd,
@@ -88,8 +88,8 @@ mod tests {
     }
 
     #[test]
-    fn unicode_norm_default_is_none() {
-        assert_eq!(UnicodeNorm::default(), UnicodeNorm::None);
+    fn unicode_norm_default_is_nfc() {
+        assert_eq!(UnicodeNorm::default(), UnicodeNorm::Nfc);
     }
 
     #[test]

--- a/crates/pdfplumber/tests/accuracy_benchmark.rs
+++ b/crates/pdfplumber/tests/accuracy_benchmark.rs
@@ -329,7 +329,12 @@ fn load_golden(pdf_stem: &str) -> GoldenData {
 
 fn open_pdf(subdir: &str, filename: &str) -> Result<Pdf, String> {
     let path = fixtures_dir().join(subdir).join(filename);
-    Pdf::open_file(&path, None).map_err(|e| format!("{}", e))
+    // Use UnicodeNorm::None to match golden data generated without normalization.
+    let opts = pdfplumber::ExtractOptions {
+        unicode_norm: pdfplumber::UnicodeNorm::None,
+        ..pdfplumber::ExtractOptions::default()
+    };
+    Pdf::open_file(&path, Some(opts)).map_err(|e| format!("{}", e))
 }
 
 /// Run the full accuracy benchmark for a single PDF.

--- a/crates/pdfplumber/tests/cross_validation.rs
+++ b/crates/pdfplumber/tests/cross_validation.rs
@@ -128,7 +128,12 @@ fn load_golden(pdf_name: &str) -> GoldenData {
 
 fn open_pdf(pdf_name: &str) -> pdfplumber::Pdf {
     let path = fixtures_dir().join("pdfs").join(pdf_name);
-    pdfplumber::Pdf::open_file(&path, None)
+    // Use UnicodeNorm::None to match golden data generated without normalization.
+    let opts = pdfplumber::ExtractOptions {
+        unicode_norm: pdfplumber::UnicodeNorm::None,
+        ..pdfplumber::ExtractOptions::default()
+    };
+    pdfplumber::Pdf::open_file(&path, Some(opts))
         .unwrap_or_else(|e| panic!("Failed to open PDF {}: {}", path.display(), e))
 }
 
@@ -704,7 +709,12 @@ fn try_validate_pdf(pdf_path: &str) -> PdfResult {
         }
     };
 
-    let pdf = match pdfplumber::Pdf::open_file(&pdf_file, None) {
+    // Use UnicodeNorm::None to match golden data generated without normalization.
+    let opts = pdfplumber::ExtractOptions {
+        unicode_norm: pdfplumber::UnicodeNorm::None,
+        ..pdfplumber::ExtractOptions::default()
+    };
+    let pdf = match pdfplumber::Pdf::open_file(&pdf_file, Some(opts)) {
         Ok(p) => p,
         Err(e) => {
             return PdfResult {

--- a/crates/pdfplumber/tests/pdf_integration.rs
+++ b/crates/pdfplumber/tests/pdf_integration.rs
@@ -1512,7 +1512,7 @@ fn unicode_norm_nfc_composes_extracted_chars() {
     // and test normalization by checking the default (no norm) vs NFC
     let bytes = pdf_with_content(b"BT /F1 12 Tf (Hello) Tj ET");
 
-    // Without normalization (default)
+    // With NFC normalization (default)
     let pdf_default = Pdf::open(&bytes, None).unwrap();
     let page_default = pdf_default.page(0).unwrap();
     assert_eq!(page_default.chars().len(), 5);

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -1,29 +1,27 @@
 {
   "project": "pdfplumber-rs",
-  "branchName": "ralph/issue-152-line-clustering",
-  "description": "Issue #152: Optimize O(n²) word-to-line clustering using y-coordinate bucketing",
-  "relatedIssue": 152,
+  "branchName": "ralph/issue-153-unicode-nfc",
+  "description": "Issue #153: Change default Unicode normalization to NFC and add for_llm() preset",
+  "relatedIssue": 153,
   "userStories": [
     {
-      "id": "US-152-1",
-      "title": "Optimize cluster_words_into_lines with y-coordinate bucketing",
-      "description": "Refactor the `cluster_words_into_lines` function in `crates/pdfplumber-core/src/layout.rs` (lines 54-103) to eliminate O(n²) complexity. The current implementation iterates through all existing lines for each word to find a match within `y_tolerance`. Replace the linear scan with a y-coordinate bucketing approach: group lines by y-coordinate ranges (buckets of size `y_tolerance`) so that for each new word, only 1-2 relevant buckets are checked instead of all lines. This brings complexity from O(n²) down to approximately O(n). The refactored function must produce identical output for all existing tests. Add a benchmark test with 10,000+ words across many lines to verify performance improvement.",
+      "id": "US-153-1",
+      "title": "Change UnicodeNorm default to Nfc and add for_llm() preset to ExtractOptions",
+      "description": "In `crates/pdfplumber-core/src/unicode_norm.rs`, change the `#[default]` attribute on the `UnicodeNorm` enum from `None` to `Nfc`. Update the doc comment on the `None` variant to remove '(default)' and add '(default)' to the `Nfc` variant doc comment. Update the `unicode_norm_default_is_none` test to assert `UnicodeNorm::default() == UnicodeNorm::Nfc`. In `crates/pdfplumber-core/src/error.rs`, update the `ExtractOptions::default()` impl to set `unicode_norm: UnicodeNorm::Nfc` (was `UnicodeNorm::None`). Add a `pub fn for_llm() -> Self` constructor to `ExtractOptions` that returns options optimized for LLM consumption: `unicode_norm: UnicodeNorm::Nfc` plus current defaults for other fields. Update any tests that assert `UnicodeNorm::None` as the default. Fix all downstream code in pdfplumber-cli and pdfplumber that may need adjustment for the new default.",
       "acceptanceCriteria": [
-        "cluster_words_into_lines no longer scans all existing lines for each word",
-        "Uses bucket/sorted approach for line matching (O(n) or O(n log n) instead of O(n²))",
-        "All existing cluster_words_into_lines tests in layout.rs pass without modification",
-        "All existing integration tests pass (cargo test --workspace)",
-        "New benchmark test with 10,000+ words demonstrates sub-quadratic behavior",
-        "Function signature remains unchanged: pub fn cluster_words_into_lines(words: &[Word], y_tolerance: f64) -> Vec<TextLine>",
-        "Output ordering (lines top-to-bottom, words left-to-right within each line) is preserved",
-        "Edge cases handled: empty input, single word, all words on same line, overlapping y ranges",
+        "UnicodeNorm::default() returns UnicodeNorm::Nfc",
+        "#[default] attribute is on Nfc variant, not None",
+        "ExtractOptions::default().unicode_norm == UnicodeNorm::Nfc",
+        "ExtractOptions::for_llm() exists and returns options with unicode_norm: UnicodeNorm::Nfc",
+        "All tests updated to reflect new default (no test expects UnicodeNorm::None as default)",
+        "Doc comments updated: Nfc says '(default)', None does not",
         "cargo fmt --all -- --check passes",
         "cargo clippy --workspace -- -D warnings passes",
         "cargo test --workspace passes"
       ],
       "priority": 1,
       "passes": true,
-      "notes": "Key file: crates/pdfplumber-core/src/layout.rs lines 54-103. The current code sorts words by (top, x0) then iterates `lines` vec for each word. A HashMap<i64, usize> keyed by quantized y-coordinate (e.g., (mid_y / y_tolerance) as i64) mapping to line indices would reduce lookups to O(1) amortized. Check adjacent buckets (key-1, key, key+1) to handle boundary cases. Existing tests at lines 314-760 cover many edge cases."
+      "notes": "Key files: crates/pdfplumber-core/src/unicode_norm.rs (enum definition, line 17-29), crates/pdfplumber-core/src/error.rs (ExtractOptions default, line 219). Tests to update: unicode_norm.rs:91 (unicode_norm_default_is_none), error.rs:445 (assert_eq opts.unicode_norm UnicodeNorm::None), error.rs:455. The CLI already handles unicode_norm as Option<UnicodeNormArg> which overrides the default, so it should be unaffected. Check crates/pdfplumber/src/pdf.rs:478 where `UnicodeNorm::None` is used as a comparison — this is checking if normalization is not None, so it should use != pattern which still works."
     }
   ]
 }

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -20,3 +20,24 @@ Started: 2026년  3월  1일 일요일 10시 16분 06초 KST
   - Zero tolerance requires special bucket_size (1e-9) to avoid division by zero
   - pdfplumber-py tests fail locally due to missing libpython3.11 — pre-existing environment issue, not related to changes
 ---
+
+## 2026-03-01 - US-153-1
+- Changed `UnicodeNorm` default from `None` to `Nfc` (moved `#[default]` attribute)
+- Updated doc comments: `Nfc` now says "(default)", `None` no longer does
+- Changed `ExtractOptions::default()` to use `UnicodeNorm::Nfc`
+- Added `ExtractOptions::for_llm()` constructor with NFC normalization
+- Updated `ExtractOptions` doc comment for `unicode_norm` field
+- Updated tests: `unicode_norm_default_is_nfc`, `extract_options_default_values`, new `extract_options_for_llm`
+- Files changed:
+  - `crates/pdfplumber-core/src/unicode_norm.rs` (enum default + doc comments + test)
+  - `crates/pdfplumber-core/src/error.rs` (default impl + for_llm() + doc comment + tests)
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - `pdf.rs:478` uses `!= UnicodeNorm::None` for skip-normalization check — this pattern works regardless of default
+  - pdfplumber-py tests fail locally due to missing libpython3.11 — pre-existing env issue, CI handles it
+  - The `extract_options_custom_values` test explicitly sets `UnicodeNorm::None` which is fine (testing custom, not default)
+  - When main diverges significantly, reset branch to main and re-apply changes rather than rebasing
+  - Cross-validation and accuracy benchmark tests compare against golden data generated without normalization. Must use explicit `UnicodeNorm::None` when opening PDFs for golden data comparison.
+  - `U+037E` (Greek Question Mark) NFC-normalizes to `U+003B` (semicolon) — caused cv_python_issue_905 failure until cross-validation/accuracy tests were fixed
+  - Also updated: `cross_validation.rs`, `accuracy_benchmark.rs` (explicit `UnicodeNorm::None`), `pdf_integration.rs` (comment fix)
+---


### PR DESCRIPTION
## Summary
- Changed `UnicodeNorm` default from `None` to `Nfc` — NFC normalization is now applied by default to all extracted text, ensuring consistent Unicode representation
- Added `ExtractOptions::for_llm()` constructor that returns options optimized for LLM consumption (NFC normalization + standard defaults)
- Updated doc comments, tests, and `ExtractOptions::default()` to reflect the new default
- Fixed cross-validation and accuracy benchmark tests to use explicit `UnicodeNorm::None` for golden data comparison (golden data was generated without normalization)

Closes #153

## Test plan
- [x] `unicode_norm_default_is_nfc` — verifies `UnicodeNorm::default()` returns `Nfc`
- [x] `extract_options_default_values` — verifies `ExtractOptions::default().unicode_norm == Nfc`
- [x] `extract_options_for_llm` — verifies `for_llm()` returns options with NFC normalization
- [x] All existing normalization tests still pass (None, Nfc, Nfd, Nfkc, Nfkd)
- [x] Cross-validation tests pass (golden data comparison uses explicit `UnicodeNorm::None`)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)