### PR TITLE
feat: US-164-2 - Fix parse error on pr-138-example.pdf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f560f57dfb9142a02d673e137622fd515d4231e51feb8b4af28d92647d83f35b"
+dependencies = [
+ "aes",
+ "bitflags",
+ "cbc",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.3.4",
+ "indexmap",
+ "itoa",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "nom_locate",
+ "rand",
+ "rangemap",
+ "sha2",
+ "stringprep",
+ "thiserror",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,7 +1033,7 @@ name = "pdfplumber-parse"
 version = "0.2.0"
 dependencies = [
  "encoding_rs",
- "lopdf 0.34.0",
+ "lopdf 0.39.0",
  "md5",
  "pdfplumber-core",
  "thiserror",
@@ -1551,6 +1579,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typenum"

--- a/crates/pdfplumber-parse/Cargo.toml
+++ b/crates/pdfplumber-parse/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["parser-implementations"]
 
 [dependencies]
 pdfplumber-core = { version = "0.2.0", path = "../pdfplumber-core" }
-lopdf = { version = "0.34", default-features = false, features = ["nom_parser"] }
+lopdf = { version = "0.39", default-features = false }
 thiserror = "2"
 encoding_rs = "0.8"
 

--- a/crates/pdfplumber-parse/src/backend.rs
+++ b/crates/pdfplumber-parse/src/backend.rs
@@ -44,10 +44,13 @@ pub trait PdfBackend {
 
     /// Parse PDF bytes into a document.
     ///
+    /// PDFs encrypted with an empty user password are auto-decrypted.
+    ///
     /// # Errors
     ///
     /// Returns an error if the bytes do not represent a valid PDF document.
-    /// If the document is encrypted, returns [`PdfError::PasswordRequired`].
+    /// If the document is encrypted with a non-empty password, returns
+    /// [`PdfError::PasswordRequired`].
     fn open(bytes: &[u8]) -> Result<Self::Document, Self::Error>;
 
     /// Parse PDF bytes into a document, decrypting with the given password.

--- a/crates/pdfplumber/tests/cross_validation.rs
+++ b/crates/pdfplumber/tests/cross_validation.rs
@@ -1229,7 +1229,7 @@ cross_validate_ignored!(
 );
 cross_validate_ignored!(cv_python_issue_848, "issue-848.pdf", "PDF parse error");
 cross_validate!(cv_python_pr_136, "pr-136-example.pdf", 0.15, 0.05);
-cross_validate_ignored!(cv_python_pr_138, "pr-138-example.pdf", "PDF parse error");
+cross_validate!(cv_python_pr_138, "pr-138-example.pdf", 0.15, 0.05);
 
 // ─── pdfjs: PASSING tests (chars/words >= 80%) ───────────────────────────
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -31,7 +31,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "Test: crates/pdfplumber/tests/real_world_cross_validation.rs (rw_pr_138). If the fix for pr-136-example.pdf also fixes this one, mark both stories as passes. 316 rects and 4 tables suggest complex graphical content."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -16,6 +16,17 @@ Started: 2026년  3월  1일 일요일 14시 50분 09초 KST
 - For simple fonts: extracts FontMetrics, /Encoding, ToUnicode CMap
 - Unicode resolution chain: ToUnicode CMap → FontEncoding → CJK encoding → char::from_u32
 
+### PDF Encryption Handling
+- `open()` auto-decrypts PDFs with empty user password (matching Python pdfplumber behavior)
+- lopdf 0.39 supports V=4/R=4 encryption (128-bit RC4 with crypt filters); 0.34 did not
+- lopdf 0.39 changed `as_name_str()` → `as_name()` returning `&[u8]` instead of `&str`
+- lopdf 0.39 `decrypt()` takes `&str`, `decrypt_raw()` takes `AsRef<[u8]>`
+- lopdf 0.39 `save_to()` uses object streams by default — manual object encryption breaks roundtrip
+
+### Content Stream Arrays
+- `/Contents` can be: Reference→Stream, Reference→Array, or direct Array
+- Always resolve references before checking type (don't assume Reference→Stream)
+
 ---
 
 ## 2026-03-01 - US-164-1
@@ -33,4 +44,29 @@ Started: 2026년  3월  1일 일요일 14시 50분 09초 KST
   - GBK-EUC-H is a variable-length encoding: 0x00-0x80 single byte, 0x81-0xFE lead byte of 2-byte sequence
   - The cross-validation char match rate (17.6%) is low due to coordinate differences (~2.7pt in top), not text extraction issues
   - Font name differences: our parser uses Type0 BaseFont (e.g., "SimSun-GBK-EUC-H") while Python pdfplumber uses CIDFont descendant BaseFont ("SimSun")
+---
+
+## 2026-03-01 - US-164-2
+- **What was implemented**: Three fixes to parse pr-138-example.pdf
+  1. Auto-decrypt PDFs with empty user password in `open()` (matching Python pdfplumber)
+  2. Upgrade lopdf from 0.34 to 0.39 for V=4/R=4 encryption support (128-bit RC4 with crypt filters)
+  3. Handle `/Contents` as Reference→Array (not just Reference→Stream or direct Array)
+- **Root causes**:
+  - pr-138-example.pdf uses V=4, R=4 encryption with empty user password. lopdf 0.34 didn't support V=4.
+  - After decryption, page `/Contents` was an indirect reference to an array of stream references, which the parser didn't handle.
+- **Files changed**:
+  - `crates/pdfplumber-parse/Cargo.toml` — upgraded lopdf from 0.34 to 0.39
+  - `crates/pdfplumber-parse/src/lopdf_backend.rs` — auto-decrypt empty password, fix Contents array handling, adapt to lopdf 0.39 API (as_name_str→as_name, decrypt signature)
+  - `crates/pdfplumber-parse/src/interpreter.rs` — adapt as_name() return type from &str to &[u8]
+  - `crates/pdfplumber-parse/src/cid_font.rs` — adapt as_name() return type from &str to &[u8]
+  - `crates/pdfplumber-parse/src/backend.rs` — updated doc comments
+  - `crates/pdfplumber/src/pdf.rs` — updated doc comments, fixed encryption test
+  - `crates/pdfplumber/tests/cross_validation.rs` — enabled pr-138 test
+- **Dependencies changed**: lopdf 0.34 → 0.39 (V=4/R=4 encryption, AES support)
+- **Result**: pr-138-example.pdf extracts 10635 chars (100% match), 99.2% word match, 100% lines/rects
+- **Learnings for future iterations:**
+  - lopdf 0.39 is a breaking upgrade: as_name_str() removed, decrypt() signature changed, Object::Name stores Vec<u8> not String
+  - Many PDFs use "owner-only" encryption (restrict print/copy) with empty user password — must auto-try empty password
+  - PDF /Contents can be indirect reference to array, not just direct array or reference to stream
+  - lopdf 0.39's save_to() uses object streams, making manual encryption helpers incompatible — use real fixture PDFs for encryption tests
 ---


### PR DESCRIPTION
## Summary
- Auto-decrypt PDFs with empty user password in `open()`, matching Python pdfplumber behavior
- Upgrade lopdf 0.34 → 0.39 for V=4/R=4 encryption support (128-bit RC4 with crypt filters)
- Handle `/Contents` as Reference→Array (not just Reference→Stream or direct Array)

## Test plan
- [x] `cargo test --workspace` passes (539 tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Cross-validation: pr-138-example.pdf extracts 10635 chars (100% match), 99.2% words, 100% lines/rects
- [x] No regression on existing tests (pr-136, all other fixtures)

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)