### PR TITLE
feat: Implement page /Rotate coordinate transformation

### DIFF
--- a/crates/pdfplumber-core/src/lib.rs
+++ b/crates/pdfplumber-core/src/lib.rs
@@ -117,8 +117,8 @@ pub use table::{
     Cell, ExplicitLines, Intersection, Strategy, Table, TableFinder, TableFinderDebug,
     TableQuality, TableSettings, cells_to_tables, duplicate_merged_content_in_table,
     edges_to_cells, edges_to_intersections, explicit_lines_to_edges, extract_text_for_cells,
-    intersections_to_cells, join_edge_group, normalize_table_columns, snap_edges,
-    words_to_edges_stream,
+    extract_text_for_cells_with_options, intersections_to_cells, join_edge_group,
+    normalize_table_columns, snap_edges, words_to_edges_stream,
 };
 pub use text::{Char, TextDirection, is_cjk, is_cjk_text};
 pub use unicode_norm::{UnicodeNorm, normalize_chars};

--- a/crates/pdfplumber/src/lib.rs
+++ b/crates/pdfplumber/src/lib.rs
@@ -118,9 +118,9 @@ pub use pdfplumber_core::{
     cluster_lines_into_blocks, cluster_words_into_lines, derive_edges, detect_columns,
     edge_from_curve, edge_from_line, edges_from_rect, edges_to_cells, edges_to_intersections,
     explicit_lines_to_edges, export_image_set, extract_shapes, extract_text_for_cells,
-    image_from_ctm, intersections_to_cells, is_cjk, is_cjk_text, join_edge_group,
-    normalize_table_columns, snap_edges, sort_blocks_column_order, sort_blocks_reading_order,
-    split_lines_at_columns, words_to_edges_stream, words_to_text,
+    extract_text_for_cells_with_options, image_from_ctm, intersections_to_cells, is_cjk,
+    is_cjk_text, join_edge_group, normalize_table_columns, snap_edges, sort_blocks_column_order,
+    sort_blocks_reading_order, split_lines_at_columns, words_to_edges_stream, words_to_text,
 };
 pub use pdfplumber_parse::{
     self, CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, LopdfPage,

--- a/crates/pdfplumber/src/page.rs
+++ b/crates/pdfplumber/src/page.rs
@@ -4,11 +4,11 @@ use pdfplumber_core::{
     Annotation, BBox, Char, ColumnMode, Curve, DedupeOptions, Edge, ExportedImage, ExtractWarning,
     FormField, HtmlOptions, HtmlRenderer, Hyperlink, Image, ImageExportOptions, Line, PageObject,
     PageRegions, Rect, SearchMatch, SearchOptions, StructElement, Table, TableFinder,
-    TableSettings, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text,
+    TableSettings, TextDirection, TextOptions, Word, WordExtractor, WordOptions, blocks_to_text,
     cluster_lines_into_blocks, cluster_words_into_lines, dedupe_chars, derive_edges,
-    detect_columns, duplicate_merged_content_in_table, export_image_set, extract_text_for_cells,
-    normalize_table_columns, search_chars, sort_blocks_column_order, sort_blocks_reading_order,
-    split_lines_at_columns, words_to_text,
+    detect_columns, duplicate_merged_content_in_table, export_image_set,
+    extract_text_for_cells_with_options, normalize_table_columns, search_chars,
+    sort_blocks_column_order, sort_blocks_reading_order, split_lines_at_columns, words_to_text,
 };
 
 use crate::cropped_page::{CroppedPage, FilterMode, PageData, filter_and_build, from_page_data};
@@ -224,6 +224,66 @@ impl Page {
         self.rotation
     }
 
+    /// Join words for rotated pages, grouping into lines based on the rotation.
+    ///
+    /// For 90°/270° rotation (vertical text), words on the same column (similar x)
+    /// are joined with spaces; different columns are separated by newlines.
+    /// For 180° rotation (reversed horizontal), words on the same row (similar y)
+    /// are joined with spaces; different rows are separated by newlines.
+    fn join_rotated_words(words: &[Word], rotation: i32, tolerance: f64) -> String {
+        if words.is_empty() {
+            return String::new();
+        }
+        let rotation = rotation % 360;
+        let mut lines: Vec<String> = Vec::new();
+        let mut current: Vec<&str> = Vec::new();
+        let mut last_key: Option<f64> = None;
+
+        for word in words {
+            let key = match rotation {
+                90 | 270 => word.bbox.x0, // vertical: lines by x
+                _ => word.bbox.top,       // horizontal: lines by y
+            };
+            if let Some(prev) = last_key {
+                if (key - prev).abs() > tolerance && !current.is_empty() {
+                    lines.push(current.join(" "));
+                    current.clear();
+                }
+            }
+            current.push(&word.text);
+            last_key = Some(key);
+        }
+        if !current.is_empty() {
+            lines.push(current.join(" "));
+        }
+        lines.join("\n")
+    }
+
+    /// Rotate a text direction by the given page rotation angle (clockwise).
+    fn rotate_text_direction(dir: TextDirection, rotation: i32) -> TextDirection {
+        match rotation % 360 {
+            90 => match dir {
+                TextDirection::Ltr => TextDirection::Ttb,
+                TextDirection::Rtl => TextDirection::Btt,
+                TextDirection::Ttb => TextDirection::Rtl,
+                TextDirection::Btt => TextDirection::Ltr,
+            },
+            180 => match dir {
+                TextDirection::Ltr => TextDirection::Rtl,
+                TextDirection::Rtl => TextDirection::Ltr,
+                TextDirection::Ttb => TextDirection::Btt,
+                TextDirection::Btt => TextDirection::Ttb,
+            },
+            270 => match dir {
+                TextDirection::Ltr => TextDirection::Btt,
+                TextDirection::Rtl => TextDirection::Ttb,
+                TextDirection::Ttb => TextDirection::Ltr,
+                TextDirection::Btt => TextDirection::Rtl,
+            },
+            _ => dir,
+        }
+    }
+
     /// Returns the page bounding box: `(0, 0, width, height)`.
     pub fn bbox(&self) -> BBox {
         BBox::new(0.0, 0.0, self.width, self.height)
@@ -359,8 +419,19 @@ impl Page {
     ///
     /// Groups characters into words based on spatial proximity using
     /// `x_tolerance` and `y_tolerance` from the options.
+    ///
+    /// When the page has a `/Rotate` attribute, the text direction from
+    /// `options` is automatically adjusted to match the rotated coordinate
+    /// system so that word grouping works correctly.
     pub fn extract_words(&self, options: &WordOptions) -> Vec<Word> {
-        WordExtractor::extract(&self.chars, options)
+        if self.rotation == 0 {
+            return WordExtractor::extract(&self.chars, options);
+        }
+        let adjusted = WordOptions {
+            text_direction: Self::rotate_text_direction(options.text_direction, self.rotation),
+            ..options.clone()
+        };
+        WordExtractor::extract(&self.chars, &adjusted)
     }
 
     /// Extract text from this page.
@@ -377,8 +448,26 @@ impl Page {
             ..WordOptions::default()
         });
 
-        if !options.layout {
+        if !options.layout && self.rotation == 0 {
             return words_to_text(&words, options.y_tolerance);
+        }
+
+        if !options.layout {
+            // For rotated pages, use text flow order to preserve correct reading
+            // order. The standard words_to_text re-sorts words by x0 (LTR) which
+            // breaks rotated reading order. We also set the rotated text direction
+            // so the word splitter uses the correct axis (vertical vs horizontal).
+            let flow_words = WordExtractor::extract(
+                &self.chars,
+                &WordOptions {
+                    y_tolerance: options.y_tolerance,
+                    expand_ligatures: options.expand_ligatures,
+                    use_text_flow: true,
+                    text_direction: Self::rotate_text_direction(TextDirection::Ltr, self.rotation),
+                    ..WordOptions::default()
+                },
+            );
+            return Self::join_rotated_words(&flow_words, self.rotation, options.y_tolerance);
         }
 
         let lines = cluster_words_into_lines(&words, options.y_tolerance);
@@ -443,15 +532,18 @@ impl Page {
         let finder = TableFinder::new_with_words(edges, words, settings.clone());
         let mut tables = finder.find_tables();
 
-        // Populate cell text from page characters
+        // Populate cell text from page characters (rotation-aware)
+        let cell_word_opts = WordOptions {
+            text_direction: Self::rotate_text_direction(TextDirection::Ltr, self.rotation),
+            ..WordOptions::default()
+        };
         for table in &mut tables {
-            extract_text_for_cells(&mut table.cells, &self.chars);
-            // Also populate text in rows and columns
+            extract_text_for_cells_with_options(&mut table.cells, &self.chars, &cell_word_opts);
             for row in &mut table.rows {
-                extract_text_for_cells(row, &self.chars);
+                extract_text_for_cells_with_options(row, &self.chars, &cell_word_opts);
             }
             for col in &mut table.columns {
-                extract_text_for_cells(col, &self.chars);
+                extract_text_for_cells_with_options(col, &self.chars, &cell_word_opts);
             }
         }
 

--- a/crates/pdfplumber/tests/cross_validation.rs
+++ b/crates/pdfplumber/tests/cross_validation.rs
@@ -1182,11 +1182,38 @@ cross_validate_ignored!(
     "mcid_example.pdf",
     "chars 0% — tagged PDF structure not supported"
 );
-cross_validate_ignored!(
-    cv_python_nics_rotated,
-    "nics-background-checks-2015-11-rotated.pdf",
-    "chars 0% — page rotation not fully supported"
-);
+/// nics-background-checks-2015-11-rotated.pdf: same content as nics-background-checks-2015-11.pdf
+/// but with /Rotate 90 on the page dictionary. Verifies that page rotation is correctly applied
+/// to all extracted objects (chars, words, lines, rects, tables).
+#[test]
+fn cross_validate_nics_rotated() {
+    let result = validate_pdf("nics-background-checks-2015-11-rotated.pdf");
+    assert!(result.parse_error.is_none(), "parse error");
+    assert!(
+        result.total_char_rate() >= CHAR_THRESHOLD,
+        "char rate {:.1}% < {:.1}%",
+        result.total_char_rate() * 100.0,
+        CHAR_THRESHOLD * 100.0,
+    );
+    assert!(
+        result.total_word_rate() >= WORD_THRESHOLD,
+        "word rate {:.1}% < {:.1}%",
+        result.total_word_rate() * 100.0,
+        WORD_THRESHOLD * 100.0,
+    );
+    assert!(
+        result.total_line_rate() >= CHAR_THRESHOLD,
+        "line rate {:.1}% < {:.1}%",
+        result.total_line_rate() * 100.0,
+        CHAR_THRESHOLD * 100.0,
+    );
+    assert!(
+        result.total_rect_rate() >= CHAR_THRESHOLD,
+        "rect rate {:.1}% < {:.1}%",
+        result.total_rect_rate() * 100.0,
+        CHAR_THRESHOLD * 100.0,
+    );
+}
 cross_validate_ignored!(
     cv_python_pdf_structure,
     "pdf_structure.pdf",

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -19,7 +19,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "Key files: crates/pdfplumber/src/page.rs (Page API), crates/pdfplumber-parse/src/interpreter.rs (content stream interpreter). The /Rotate value is in the page dictionary and can be inherited from parent nodes in the page tree. Python pdfplumber applies rotation as a coordinate transform: 90° rotates (x,y) → (y, width-x), 180° → (width-x, height-y), 270° → (height-y, x). The page's MediaBox dimensions should also be adjusted (width↔height swap for 90°/270°). Check how lopdf exposes the /Rotate key."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,10 +1,14 @@
-## Codebase Patterns
-- `try_fix_startxref()` pattern: when lopdf fails to parse, attempt recovery by scanning for the actual xref offset and patching the bytes before retrying. This is a general pattern for handling malformed PDFs.
-- Cross-validation tests: use `cross_validate!` macro for PDFs that parse successfully, `cross_validate_ignored!` for known failures. When fixing a parse error, update from ignored to passing.
-- Backend unit tests for issue-specific PDFs: check fixture existence with `if !pdf_path.exists()` and skip gracefully to avoid CI failures when fixtures are missing.
-
+# Ralph Progress Log
+Started: 2026년  3월  1일 일요일 16시 23분 15초 KST
 ---
-
-# Ralph Progress Log - Issue #166: Fix rotation handling for 0% extraction on rotated PDFs
-Started: 2026년  3월  1일 일요일 16시 23분 12초 KST
----
+## US-166-1: Implement page /Rotate coordinate transformation
+- Applied PageGeometry.normalize_bbox() rotation transform to chars, lines, rects, curves, images in pdf.rs
+- Added rotation-aware word extraction (text direction adjustment) in page.rs
+- Added RTL sort case and direction-aware gap formula in words.rs
+- Added rotation-aware text extraction with join_rotated_words helper
+- Added rotation-aware table cell text extraction via extract_text_for_cells_with_options
+- Cross-validation: nics-background-checks-2015-11-rotated.pdf chars=100%, words=100%, lines=100%, rects=100%
+- Non-rotated nics PDF remains at 100% (no regression)
+- All rotation integration tests pass (29 rotation + 21 table rotation)
+- cargo fmt, clippy, test --workspace all pass
+- Status: COMPLETE


### PR DESCRIPTION
## Summary
- Apply `PageGeometry.normalize_bbox()` rotation transform to all extracted objects (chars, lines, rects, curves, images) after content stream interpretation, fixing 0% extraction accuracy on rotated PDFs
- Add rotation-aware word/text/table-cell extraction with proper text direction handling (RTL for 180°, TTB for 90°, BTT for 270°)
- Fix word splitting gap formula: direction-agnostic interval gap for RTL, abs-based gap for LTR (preserves backward-jump detection)

## Results
- `nics-background-checks-2015-11-rotated.pdf`: **100% F1** for chars, words, lines, and rects (was 0%)
- Non-rotated `nics-background-checks-2015-11.pdf`: remains at **100%** (no regression)
- All 29 rotation integration tests + 21 rotation table integration tests pass
- `cargo test --workspace`, `cargo fmt --check`, `cargo clippy -D warnings` all pass

## Test plan
- [x] Cross-validation test for rotated NICS PDF (chars, words, lines, rects ≥90% F1)
- [x] Non-rotated NICS PDF unchanged at 100%
- [x] Rotation integration tests (0°, 90°, 180°, 270°) for chars, text, dimensions
- [x] Rotation table integration tests (cell text extraction for 0°, 90°, 180°)
- [x] No regression on existing tests (`cargo test --workspace`)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)