### PR TITLE
feat: US-167-1 - Fix extraction on tagged/structure PDFs

### DIFF
--- a/crates/pdfplumber-parse/src/backend.rs
+++ b/crates/pdfplumber-parse/src/backend.rs
@@ -501,6 +501,8 @@ mod tests {
                 word_spacing: 0.0,
                 h_scaling: 1.0,
                 rise: 0.0,
+                ascent: 750.0,
+                descent: -250.0,
                 mcid: None,
                 tag: None,
             });

--- a/crates/pdfplumber-parse/src/handler.rs
+++ b/crates/pdfplumber-parse/src/handler.rs
@@ -46,6 +46,10 @@ pub struct CharEvent {
     pub h_scaling: f64,
     /// Text rise value (Ts operator) for superscript/subscript.
     pub rise: f64,
+    /// Font ascent in glyph space units (1/1000 of text space, positive above baseline).
+    pub ascent: f64,
+    /// Font descent in glyph space units (1/1000 of text space, negative below baseline).
+    pub descent: f64,
     /// Marked content identifier (MCID) from BDC operator, if inside a marked content sequence.
     pub mcid: Option<u32>,
     /// Structure tag name (e.g., "P", "Span", "H1") from BMC/BDC operator.
@@ -203,6 +207,8 @@ mod tests {
             word_spacing: 0.0,
             h_scaling: 1.0,
             rise: 0.0,
+            ascent: 750.0,
+            descent: -250.0,
             mcid: None,
             tag: None,
         }

--- a/crates/pdfplumber/src/pdf.rs
+++ b/crates/pdfplumber/src/pdf.rs
@@ -11,8 +11,8 @@ use pdfplumber_core::{
     normalize_chars,
 };
 use pdfplumber_parse::{
-    CharEvent, ContentHandler, FontMetrics, ImageEvent, LopdfBackend, LopdfDocument, PageGeometry,
-    PaintOp, PathEvent, PdfBackend, char_from_event,
+    CharEvent, ContentHandler, ImageEvent, LopdfBackend, LopdfDocument, PageGeometry, PaintOp,
+    PathEvent, PdfBackend, char_from_event,
 };
 
 use crate::Page;
@@ -497,7 +497,6 @@ impl Pdf {
 
         // Convert CharEvents to Chars
         let page_height = self.raw_page_heights[index];
-        let default_metrics = FontMetrics::default_metrics();
         let doctop_offset: f64 = self.page_heights[..index].iter().sum();
         let needs_rotation = geometry.rotation() != 0;
 
@@ -505,7 +504,7 @@ impl Pdf {
             .chars
             .iter()
             .map(|event| {
-                let mut ch = char_from_event(event, &default_metrics, page_height, None, None);
+                let mut ch = char_from_event(event, page_height, None, None);
                 if needs_rotation {
                     // char_from_event applied a simple y-flip using the raw page height.
                     // Undo it to recover PDF native coordinates, then apply the full

--- a/scripts/ralph/.last-branch
+++ b/scripts/ralph/.last-branch
@@ -1,1 +1,1 @@
-ralph/table-accuracy
+ralph/issue-167-zero-extraction

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -18,8 +18,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 1,
-      "passes": false,
-      "notes": "Tagged PDF operators: BMC (Begin Marked Content), BDC (Begin Marked Content with properties), EMC (End Marked Content), MP (Marked Content Point), DP (Marked Content Point with properties). These should be handled (or safely skipped) in the content stream interpreter at crates/pdfplumber-parse/src/interpreter.rs. The text between BMC/EMC pairs should still be extracted normally."
+      "passes": true,
+      "notes": "Fixed. Root cause: fonts with Ascent=0/Descent=0 in font descriptors caused vertical bbox mismatch. Fix: when both ascent and descent are zero, use 1000/0 so bbox spans baseline to baseline+fontsize (matching pdfminer behavior). All three PDFs now at F1>=0.98."
     },
     {
       "id": "US-167-2",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,3 +1,9 @@
-# Ralph Progress Log - Issue #167: Fix 0% extraction on structure tags, page boxes, extra attrs
-Started: 2026년  3월  1일 일요일 17시 13분 11초 KST
+# Ralph Progress Log
+Started: 2026년  3월  1일 일요일 17시 13분 12초 KST
 ---
+## US-167-1: Fix extraction on tagged/structure PDFs
+- Root cause: Fonts with Ascent=0/Descent=0 in descriptors caused vertical bbox mismatch (0% F1)
+- Fix: Added per-font ascent/descent to CharEvent; when both are zero, use 1000/0 (pdfminer behavior)
+- Results: figure_structure F1=1.000, hello_structure F1=0.981, pdf_structure F1=1.000
+- Files changed: handler.rs, interpreter.rs, char_extraction.rs, backend.rs, pdf.rs, accuracy_benchmark.rs
+- Status: DONE


### PR DESCRIPTION
## Summary
- Fix 0% char extraction on `figure_structure.pdf`, `hello_structure.pdf`, and `pdf_structure.pdf` caused by fonts with Ascent=0/Descent=0 in their font descriptors
- Add per-font ascent/descent fields to `CharEvent` so the interpreter can pass font-specific metrics to char extraction
- When both Ascent=0 AND Descent=0 in the font descriptor (signals "unknown"), use ascent=1000/descent=0 so bbox spans baseline to baseline+fontsize (matching pdfminer behavior)

## Key Changes
- **`handler.rs`**: Added `ascent` and `descent` fields to `CharEvent`
- **`interpreter.rs`**: Populate ascent/descent with smart defaults — 750/-250 for normal fonts, 1000/0 when both are zero
- **`char_extraction.rs`**: Use `event.ascent`/`event.descent` instead of separate `FontMetrics` parameter
- **`pdf.rs`**: Removed `FontMetrics::default_metrics()` usage, simplified `char_from_event` call
- **`accuracy_benchmark.rs`**: Added accuracy tests for all three structure PDFs with >90% F1 threshold

## Results
| PDF | Chars F1 | Words F1 |
|-----|----------|----------|
| figure_structure.pdf | 1.000 | 1.000 |
| hello_structure.pdf | 0.981 | 1.000 |
| pdf_structure.pdf | 1.000 | 1.000 |

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace --exclude pdfplumber-py` passes (0 failures)
- [x] No regressions on existing cross-validation or accuracy tests

Related: #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)