### PR TITLE
feat: US-167-2 - Fix extraction on government docs and page-box PDFs

### DIFF
--- a/crates/pdfplumber-parse/src/interpreter.rs
+++ b/crates/pdfplumber-parse/src/interpreter.rs
@@ -1081,11 +1081,17 @@ fn emit_char_events(
         };
 
         // Ascent/descent for bounding box calculation.
-        // Use standard defaults (750/-250) to match pdfminer behavior for most fonts.
-        // Only override when both Ascent=0 AND Descent=0 in the font descriptor,
-        // which signals "unknown" — use 1000/0 so bbox spans baseline to baseline+fontsize.
+        // Match pdfminer behavior: use the font descriptor's Descent value and
+        // derive ascent as (1000 + descent). This keeps height = font_size while
+        // anchoring the bottom to the font's actual descent below the baseline.
+        // When both Ascent=0 AND Descent=0 (signals "unknown"), use 1000/0 so
+        // bbox spans baseline to baseline+fontsize.
         let (ascent, descent) = match cached {
             Some(cf) if cf.metrics.ascent() == 0.0 && cf.metrics.descent() == 0.0 => (1000.0, 0.0),
+            Some(cf) => {
+                let desc = cf.metrics.descent();
+                (1000.0 + desc, desc)
+            }
             _ => (750.0, -250.0),
         };
 

--- a/crates/pdfplumber/tests/accuracy_benchmark.rs
+++ b/crates/pdfplumber/tests/accuracy_benchmark.rs
@@ -831,6 +831,86 @@ fn accuracy_pdf_structure() {
 }
 
 // ---------------------------------------------------------------------------
+// Government docs & page-box PDF tests (US-167-2)
+//
+// PDFs with page box variations, CIDFont/Type1C fonts, extra dictionary
+// attributes, and malformed content. Historically produced 0% extraction.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accuracy_senate_expenditures() {
+    let (cf1, wf1) = benchmark_pdf_crate("pdfs", "senate-expenditures.pdf", "senate-expenditures")
+        .expect("senate-expenditures.pdf should parse");
+    print_text_summary("senate-expenditures.pdf", &cf1, &wf1);
+    // US-167-2: Char extraction — Python expects 3880 chars
+    assert!(
+        cf1.f1 >= 0.90,
+        "senate-expenditures chars F1 {:.3} < 0.90",
+        cf1.f1
+    );
+}
+
+#[test]
+fn accuracy_la_precinct_bulletin() {
+    let (cf1, wf1) = benchmark_pdf_crate(
+        "pdfs",
+        "la-precinct-bulletin-2014-p1.pdf",
+        "la-precinct-bulletin-2014-p1",
+    )
+    .expect("la-precinct-bulletin-2014-p1.pdf should parse");
+    print_text_summary("la-precinct-bulletin-2014-p1.pdf", &cf1, &wf1);
+    // US-167-2: Char extraction — Python expects 1996 chars
+    assert!(
+        cf1.f1 >= 0.50,
+        "la-precinct-bulletin chars F1 {:.3} < 0.50",
+        cf1.f1
+    );
+}
+
+#[test]
+fn accuracy_page_boxes_example() {
+    let (cf1, wf1) = benchmark_pdf_crate("pdfs", "page-boxes-example.pdf", "page-boxes-example")
+        .expect("page-boxes-example.pdf should parse");
+    print_text_summary("page-boxes-example.pdf", &cf1, &wf1);
+    // US-167-2: Char extraction >50% — Python expects 28 chars
+    assert!(
+        cf1.f1 >= 0.50,
+        "page-boxes-example chars F1 {:.3} < 0.50",
+        cf1.f1
+    );
+}
+
+#[test]
+fn accuracy_extra_attrs_example() {
+    let (cf1, wf1) = benchmark_pdf_crate("pdfs", "extra-attrs-example.pdf", "extra-attrs-example")
+        .expect("extra-attrs-example.pdf should parse");
+    print_text_summary("extra-attrs-example.pdf", &cf1, &wf1);
+    // US-167-2: Char extraction — Python expects 13 chars
+    assert!(
+        cf1.f1 >= 0.50,
+        "extra-attrs-example chars F1 {:.3} < 0.50",
+        cf1.f1
+    );
+}
+
+#[test]
+fn accuracy_malformed_from_issue_932() {
+    let (cf1, wf1) = benchmark_pdf_crate(
+        "pdfs",
+        "malformed-from-issue-932.pdf",
+        "malformed-from-issue-932",
+    )
+    .expect("malformed-from-issue-932.pdf should parse");
+    print_text_summary("malformed-from-issue-932.pdf", &cf1, &wf1);
+    // US-167-2: Char extraction — Python expects 7 chars
+    assert!(
+        cf1.f1 >= 0.50,
+        "malformed-from-issue-932 chars F1 {:.3} < 0.50",
+        cf1.f1
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Aggregate summary test
 // ---------------------------------------------------------------------------
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -36,8 +36,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
-      "notes": "page-boxes-example.pdf has CropBox/MediaBox/BleedBox - coordinate space may differ from MediaBox. extra-attrs-example.pdf may have unusual dictionary entries. malformed-from-issue-932.pdf may need error recovery. Check if these share the same root cause as the structure PDFs (tagged PDF operators)."
+      "passes": true,
+      "notes": "Fixed. Three sub-issues: (1) page-boxes-example, senate-expenditures, la-precinct-bulletin already passed after US-167-1 fix. (2) extra-attrs-example: pdfminer uses font descriptor Descent and derives ascent=1000+descent; fixed interpreter to match. (3) malformed-from-issue-932: inverted MediaBox [0,841.68,631,0] caused negative page height; fixed by computing effective height as top+|height|."
     },
     {
       "id": "US-167-3",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -7,3 +7,11 @@ Started: 2026년  3월  1일 일요일 17시 13분 12초 KST
 - Results: figure_structure F1=1.000, hello_structure F1=0.981, pdf_structure F1=1.000
 - Files changed: handler.rs, interpreter.rs, char_extraction.rs, backend.rs, pdf.rs, accuracy_benchmark.rs
 - Status: DONE
+
+## US-167-2: Fix extraction on government docs and page-box PDFs
+- senate-expenditures, la-precinct-bulletin, page-boxes-example: already passing after US-167-1
+- extra-attrs-example: pdfminer uses descent from font descriptor, derives ascent=1000+descent; fixed interpreter
+- malformed-from-issue-932: inverted MediaBox caused negative page height; fixed with top+|height|
+- Results: all 5 PDFs at F1=1.000 for chars
+- Files changed: interpreter.rs (ascent/descent formula), pdf.rs (MediaBox height), accuracy_benchmark.rs
+- Status: DONE


### PR DESCRIPTION
## Summary
- Fix char extraction on `extra-attrs-example.pdf` and `malformed-from-issue-932.pdf`
- Three other PDFs (`senate-expenditures`, `la-precinct-bulletin`, `page-boxes-example`) already pass after US-167-1 fix
- Two root causes: per-font ascent/descent formula mismatch and inverted MediaBox handling

## Key Changes
- **`interpreter.rs`**: Use font descriptor's Descent and derive ascent = 1000 + descent (matching pdfminer). Keeps bbox height = font_size while anchoring bottom to actual descent
- **`pdf.rs`**: Compute effective page height as `media_box.top + |media_box.height()|` to handle inverted MediaBox PDFs
- **`accuracy_benchmark.rs`**: Added accuracy tests for all 5 US-167-2 PDFs

## Results
| PDF | Chars F1 | Words F1 |
|-----|----------|----------|
| senate-expenditures.pdf | 1.000 | 0.001 |
| la-precinct-bulletin-2014-p1.pdf | 1.000 | 1.000 |
| page-boxes-example.pdf | 1.000 | 1.000 |
| extra-attrs-example.pdf | 1.000 | 0.000 |
| malformed-from-issue-932.pdf | 1.000 | 1.000 |

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace --exclude pdfplumber-py` passes (0 failures)
- [x] No regressions on existing cross-validation or accuracy tests

Related: #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)