### PR TITLE
feat: US-167-3 - Add tests for issue regression PDFs (issue-140, issue-461)

### DIFF
--- a/crates/pdfplumber/tests/accuracy_benchmark.rs
+++ b/crates/pdfplumber/tests/accuracy_benchmark.rs
@@ -911,6 +911,38 @@ fn accuracy_malformed_from_issue_932() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue regression PDF tests (US-167-3)
+//
+// Regression test PDFs from the Python pdfplumber issue tracker.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accuracy_issue_140_example() {
+    let (cf1, wf1) = benchmark_pdf_crate("pdfs", "issue-140-example.pdf", "issue-140-example")
+        .expect("issue-140-example.pdf should parse");
+    print_text_summary("issue-140-example.pdf", &cf1, &wf1);
+    // US-167-3: Char extraction accuracy >80%
+    assert!(
+        cf1.f1 >= 0.80,
+        "issue-140-example chars F1 {:.3} < 0.80",
+        cf1.f1
+    );
+}
+
+#[test]
+fn accuracy_issue_461_example() {
+    let (cf1, wf1) = benchmark_pdf_crate("pdfs", "issue-461-example.pdf", "issue-461-example")
+        .expect("issue-461-example.pdf should parse");
+    print_text_summary("issue-461-example.pdf", &cf1, &wf1);
+    // US-167-3: Char extraction accuracy >80%
+    assert!(
+        cf1.f1 >= 0.80,
+        "issue-461-example chars F1 {:.3} < 0.80",
+        cf1.f1
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Aggregate summary test
 // ---------------------------------------------------------------------------
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -52,8 +52,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": "These may be fixed by the same changes that fix US-167-1 or US-167-2. Check after implementing those stories. issue-140 has tables, issue-461 is a general regression."
+      "passes": true,
+      "notes": "Fixed. Both PDFs already pass (F1=1.000 chars) after US-167-1 and US-167-2 fixes. Root causes were the same: per-font ascent/descent formula and inverted MediaBox handling."
     }
   ]
 }

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -15,3 +15,8 @@ Started: 2026년  3월  1일 일요일 17시 13분 12초 KST
 - Results: all 5 PDFs at F1=1.000 for chars
 - Files changed: interpreter.rs (ascent/descent formula), pdf.rs (MediaBox height), accuracy_benchmark.rs
 - Status: DONE
+
+## US-167-3: Fix extraction on issue regression PDFs
+- Both issue-140-example and issue-461-example already pass (F1=1.000) after US-167-1/2 fixes
+- Added accuracy tests for verification
+- Status: DONE


### PR DESCRIPTION
## Summary
- Both `issue-140-example.pdf` (709 chars) and `issue-461-example.pdf` (866 chars) already pass with F1=1.000 after US-167-1 and US-167-2 fixes
- Added accuracy benchmark tests to verify and prevent regressions
- This completes all three user stories for issue #167

## Results
| PDF | Chars F1 | Words F1 |
|-----|----------|----------|
| issue-140-example.pdf | 1.000 | 0.021 |
| issue-461-example.pdf | 1.000 | 0.028 |

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace --exclude pdfplumber-py` passes (0 failures)

Related: #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)