### PR TITLE
feat: US-182-1 - Apply StandardEncoding for Type1 fonts without /Encoding

### DIFF
--- a/crates/pdfplumber-parse/src/interpreter.rs
+++ b/crates/pdfplumber-parse/src/interpreter.rs
@@ -704,6 +704,17 @@ fn load_font_if_needed(
                     };
                 let base_name = strip_subset_prefix(raw_base_name).to_string();
 
+                // US-182-1: When a standard Type1 font has no explicit /Encoding,
+                // apply StandardEncoding as the implicit base encoding per PDF spec.
+                // Symbol and ZapfDingbats have their own built-in encodings.
+                let encoding = encoding.or_else(|| {
+                    if is_standard_latin_font(&base_name) {
+                        Some(FontEncoding::from_standard(StandardEncoding::Standard))
+                    } else {
+                        None
+                    }
+                });
+
                 (metrics, cmap, base_name, None, false, 0, encoding, None)
             }
         } else {
@@ -801,6 +812,26 @@ fn extract_font_encoding(doc: &lopdf::Document, fd: &lopdf::Dictionary) -> Optio
     }
 
     None
+}
+
+/// Check if a font name is one of the standard 14 Latin fonts (all except
+/// Symbol and ZapfDingbats, which have their own built-in encodings).
+fn is_standard_latin_font(base_name: &str) -> bool {
+    matches!(
+        base_name,
+        "Courier"
+            | "Courier-Bold"
+            | "Courier-Oblique"
+            | "Courier-BoldOblique"
+            | "Helvetica"
+            | "Helvetica-Bold"
+            | "Helvetica-Oblique"
+            | "Helvetica-BoldOblique"
+            | "Times-Roman"
+            | "Times-Bold"
+            | "Times-Italic"
+            | "Times-BoldItalic"
+    )
 }
 
 /// Parse a PDF /Differences array into (code, char) pairs.
@@ -2771,5 +2802,182 @@ mod tests {
         assert_eq!(handler.chars[0].mcid, Some(7));
         assert_eq!(handler.chars[1].tag.as_deref(), Some("P"));
         assert_eq!(handler.chars[1].mcid, Some(7));
+    }
+
+    // --- US-182-1: StandardEncoding fallback for Type1 fonts ---
+
+    /// Create resources with a standard Type1 font (e.g. Helvetica) that has NO
+    /// explicit /Encoding entry.  Per the PDF spec, StandardEncoding should be
+    /// used as the implicit base encoding for such fonts.
+    fn make_standard_type1_font_resources(doc: &mut lopdf::Document) -> lopdf::Dictionary {
+        use lopdf::{Object, dictionary};
+
+        let font_dict = dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+            // No /Encoding — StandardEncoding should be applied implicitly
+        };
+        let font_id = doc.add_object(Object::Dictionary(font_dict));
+
+        dictionary! {
+            "Font" => Object::Dictionary(dictionary! {
+                "F1" => Object::Reference(font_id),
+            }),
+        }
+    }
+
+    #[test]
+    fn standard_type1_font_uses_standard_encoding_for_0x27() {
+        // Byte 0x27 in StandardEncoding maps to 'quoteright' (U+2019),
+        // NOT ASCII apostrophe (U+0027).
+        let mut doc = lopdf::Document::with_version("1.5");
+        let resources = make_standard_type1_font_resources(&mut doc);
+
+        // Content stream: render byte 0x27 with Helvetica
+        let stream = b"BT /F1 12 Tf (I\x27ll) Tj ET";
+
+        let mut handler = CollectingHandler::new();
+        let mut gstate = InterpreterState::new();
+        let mut tstate = TextState::new();
+
+        interpret_content_stream(
+            &doc,
+            stream,
+            &resources,
+            &mut handler,
+            &default_options(),
+            0,
+            &mut gstate,
+            &mut tstate,
+        )
+        .unwrap();
+
+        assert_eq!(handler.chars.len(), 4); // I, quoteright, l, l
+        // The critical assertion: byte 0x27 must decode to U+2019, not U+0027
+        assert_eq!(
+            handler.chars[1].unicode.as_deref(),
+            Some("\u{2019}"),
+            "byte 0x27 in StandardEncoding should be quoteright (U+2019), got {:?}",
+            handler.chars[1].unicode
+        );
+    }
+
+    #[test]
+    fn standard_type1_font_keeps_ascii_letters_unchanged() {
+        // ASCII letters (0x41-0x5A, 0x61-0x7A) are the same in StandardEncoding
+        // and ASCII, so they should decode normally.
+        let mut doc = lopdf::Document::with_version("1.5");
+        let resources = make_standard_type1_font_resources(&mut doc);
+
+        let stream = b"BT /F1 12 Tf (Hello) Tj ET";
+
+        let mut handler = CollectingHandler::new();
+        let mut gstate = InterpreterState::new();
+        let mut tstate = TextState::new();
+
+        interpret_content_stream(
+            &doc,
+            stream,
+            &resources,
+            &mut handler,
+            &default_options(),
+            0,
+            &mut gstate,
+            &mut tstate,
+        )
+        .unwrap();
+
+        assert_eq!(handler.chars.len(), 5);
+        assert_eq!(handler.chars[0].unicode.as_deref(), Some("H"));
+        assert_eq!(handler.chars[1].unicode.as_deref(), Some("e"));
+        assert_eq!(handler.chars[2].unicode.as_deref(), Some("l"));
+        assert_eq!(handler.chars[3].unicode.as_deref(), Some("l"));
+        assert_eq!(handler.chars[4].unicode.as_deref(), Some("o"));
+    }
+
+    #[test]
+    fn standard_type1_font_0x60_maps_to_quoteleft() {
+        // Byte 0x60 in StandardEncoding maps to 'quoteleft' (U+2018),
+        // NOT grave accent (U+0060).
+        let mut doc = lopdf::Document::with_version("1.5");
+        let resources = make_standard_type1_font_resources(&mut doc);
+
+        let stream = b"BT /F1 12 Tf (\x60) Tj ET";
+
+        let mut handler = CollectingHandler::new();
+        let mut gstate = InterpreterState::new();
+        let mut tstate = TextState::new();
+
+        interpret_content_stream(
+            &doc,
+            stream,
+            &resources,
+            &mut handler,
+            &default_options(),
+            0,
+            &mut gstate,
+            &mut tstate,
+        )
+        .unwrap();
+
+        assert_eq!(handler.chars.len(), 1);
+        assert_eq!(
+            handler.chars[0].unicode.as_deref(),
+            Some("\u{2018}"),
+            "byte 0x60 in StandardEncoding should be quoteleft (U+2018), got {:?}",
+            handler.chars[0].unicode
+        );
+    }
+
+    #[test]
+    fn explicit_encoding_not_overridden_by_standard_fallback() {
+        // When a font has an explicit /Encoding (e.g. WinAnsiEncoding),
+        // it must NOT be overridden by the StandardEncoding fallback.
+        let mut doc = lopdf::Document::with_version("1.5");
+
+        use lopdf::{Object, dictionary};
+
+        let font_dict = dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+            "Encoding" => "WinAnsiEncoding",
+        };
+        let font_id = doc.add_object(Object::Dictionary(font_dict));
+
+        let resources = dictionary! {
+            "Font" => Object::Dictionary(dictionary! {
+                "F1" => Object::Reference(font_id),
+            }),
+        };
+
+        // Byte 0x27 in WinAnsiEncoding maps to quotesingle (U+0027)
+        let stream = b"BT /F1 12 Tf (\x27) Tj ET";
+
+        let mut handler = CollectingHandler::new();
+        let mut gstate = InterpreterState::new();
+        let mut tstate = TextState::new();
+
+        interpret_content_stream(
+            &doc,
+            stream,
+            &resources,
+            &mut handler,
+            &default_options(),
+            0,
+            &mut gstate,
+            &mut tstate,
+        )
+        .unwrap();
+
+        assert_eq!(handler.chars.len(), 1);
+        // WinAnsiEncoding: 0x27 = quotesingle (U+0027), not quoteright
+        assert_eq!(
+            handler.chars[0].unicode.as_deref(),
+            Some("'"),
+            "WinAnsiEncoding byte 0x27 should be quotesingle (U+0027), got {:?}",
+            handler.chars[0].unicode
+        );
     }
 }

--- a/crates/pdfplumber/tests/accuracy_benchmark.rs
+++ b/crates/pdfplumber/tests/accuracy_benchmark.rs
@@ -809,11 +809,16 @@ fn accuracy_hello_structure() {
     let (cf1, wf1) = benchmark_pdf_crate("pdfs", "hello_structure.pdf", "hello_structure")
         .expect("hello_structure.pdf should parse");
     print_text_summary("hello_structure.pdf", &cf1, &wf1);
-    // US-167-1: Char extraction accuracy >90%
+    // US-182-1: StandardEncoding fix brings chars/words to F1=1.0
     assert!(
-        cf1.f1 >= 0.90,
-        "hello_structure chars F1 {:.3} < 0.90",
+        cf1.f1 >= 0.99,
+        "hello_structure chars F1 {:.3} < 0.99",
         cf1.f1
+    );
+    assert!(
+        wf1.f1 >= 0.95,
+        "hello_structure words F1 {:.3} < 0.95",
+        wf1.f1
     );
 }
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -18,7 +18,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "Key files: crates/pdfplumber-parse/src/interpreter.rs (extract_font_encoding function, line ~758), crates/pdfplumber-parse/src/standard_fonts.rs. StandardEncoding differs from WinAnsiEncoding at several code points: 0x27 (quoteright vs quotesingle), 0x60 (grave vs quoteleft), 0x91-0x92, etc. The AGL (Adobe Glyph List) maps glyph names to Unicode. Standard 14 fonts: Helvetica(-Bold/-Oblique/-BoldOblique), Times-Roman(-Bold/-Italic/-BoldItalic), Courier(-Bold/-Oblique/-BoldOblique), Symbol, ZapfDingbats."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,10 +1,25 @@
+# Ralph Progress Log
+Started: 2026년  3월  1일 일요일 22시 19분 17초 KST
+
 ## Codebase Patterns
-- **Per-char direction partitioning**: When extracting words from mixed-direction text, partition chars into 4 groups by direction (Ltr/Rtl/Ttb/Btt) before sorting and grouping. Each direction needs different cluster_sort parameters. See `WordExtractor::extract()` and `extract_group()` in `words.rs`.
-- **Char direction set by interpreter**: The `direction` field on `Char` is set by `char_extraction.rs` based on the text rendering matrix (TRM). `trm.b` dominant → Ttb/Btt; `trm.a` dominant → Ltr/Rtl. For rotated pages, `rotate_direction()` in `pdf.rs` further adjusts: 90°: Ltr→Ttb, 180°: Ltr→Rtl, 270°: Ltr→Btt.
-- **Direction-aware line sorting**: `cluster_words_into_lines()` in `layout.rs` sorts words within lines based on majority direction: Rtl lines sort right-to-left (x0 descending), Ltr lines sort left-to-right (x0 ascending).
+
+- **Font encoding resolution chain**: CMap → FontEncoding → CJK encoding → char::from_u32 (interpreter.rs:1036-1073)
+- **Standard font identification**: `standard_fonts::lookup()` matches all 14 standard fonts; `is_standard_latin_font()` excludes Symbol/ZapfDingbats
+- **Font cache population**: `load_font_if_needed()` in interpreter.rs builds `CachedFont` with optional `encoding` field
+- **StandardEncoding table**: Already existed in `pdfplumber-core/src/encoding.rs` as `STANDARD_TABLE` — maps byte codes to Unicode (e.g., 0x27→U+2019 quoteright, 0x60→U+2018 quoteleft)
 
 ---
 
-# Ralph Progress Log - Issue #182: StandardEncoding fallback for Type1 fonts without explicit /Encoding
-Started: 2026년  3월  1일 일요일 22시 19분 16초 KST
+## 2026-03-01 - US-182-1
+- **What was implemented**: StandardEncoding fallback for Type1 fonts without explicit /Encoding. When a standard Latin Type1 font (Helvetica, Times, Courier variants) lacks a /Encoding entry, StandardEncoding is now applied as the implicit base encoding per the PDF spec.
+- **Files changed**:
+  - `crates/pdfplumber-parse/src/interpreter.rs` — Added `is_standard_latin_font()` function and encoding fallback logic in `load_font_if_needed()`. Added 4 unit tests.
+  - `crates/pdfplumber/tests/accuracy_benchmark.rs` — Updated hello_structure.pdf thresholds to chars F1>=0.99, words F1>=0.95.
+  - `scripts/ralph/prd.json` — Marked US-182-1 as passes: true.
+- **Dependencies added**: None
+- **Results**: hello_structure.pdf accuracy improved from chars F1=0.981/words F1=0.889 to chars F1=1.000/words F1=1.000.
+- **Learnings for future iterations:**
+  - The StandardEncoding table was already fully implemented in pdfplumber-core — the missing piece was just the fallback logic in the interpreter.
+  - Symbol and ZapfDingbats must be excluded from StandardEncoding fallback since they have their own built-in encodings.
+  - The `extract_font_encoding()` function returns `None` when no /Encoding entry exists — this is by design (early return with `?`), so the fallback must be applied at the call site.
 ---


### PR DESCRIPTION
## Summary

- Apply Adobe StandardEncoding as the implicit base encoding for standard Type1 fonts (Helvetica, Times, Courier variants) that lack an explicit `/Encoding` entry, per PDF spec Section 9.6.6.2
- Added `is_standard_latin_font()` helper to identify the 12 standard Latin fonts (excluding Symbol and ZapfDingbats which have their own encodings)
- Fixes byte 0x27 mapping: now correctly produces U+2019 (RIGHT SINGLE QUOTATION MARK) instead of U+0027 (ASCII apostrophe)
- hello_structure.pdf accuracy improved from chars F1=0.981 / words F1=0.889 to **chars F1=1.000 / words F1=1.000**

## Test plan

- [x] Unit test: `standard_type1_font_uses_standard_encoding_for_0x27` — verifies byte 0x27 maps to U+2019
- [x] Unit test: `standard_type1_font_0x60_maps_to_quoteleft` — verifies byte 0x60 maps to U+2018
- [x] Unit test: `standard_type1_font_keeps_ascii_letters_unchanged` — regression check for ASCII
- [x] Unit test: `explicit_encoding_not_overridden_by_standard_fallback` — ensures WinAnsiEncoding fonts are not affected
- [x] Accuracy benchmark: hello_structure.pdf chars F1>=0.99, words F1>=0.95
- [x] All workspace tests pass, clippy clean, fmt check passes

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)