### PR TITLE
feat: US-182-2 - Fix standard font width lookup to use glyph names

### DIFF
--- a/crates/pdfplumber-parse/src/interpreter.rs
+++ b/crates/pdfplumber-parse/src/interpreter.rs
@@ -715,6 +715,36 @@ fn load_font_if_needed(
                     }
                 });
 
+                // US-182-2: When a standard font has no /Widths array, the fallback
+                // widths from standard_fonts.rs are indexed by WinAnsiEncoding. If the
+                // active encoding differs (e.g., StandardEncoding), remap widths so each
+                // code position gets the correct glyph width for the active encoding.
+                let metrics = if fd.get(b"Widths").is_err() {
+                    if let Some(ref enc) = encoding {
+                        if let Some(remapped) =
+                            crate::standard_fonts::build_remapped_widths(&base_name, |code| {
+                                enc.decode(code)
+                            })
+                        {
+                            FontMetrics::new(
+                                remapped,
+                                0,
+                                255,
+                                metrics.missing_width(),
+                                metrics.ascent(),
+                                metrics.descent(),
+                                metrics.font_bbox(),
+                            )
+                        } else {
+                            metrics
+                        }
+                    } else {
+                        metrics
+                    }
+                } else {
+                    metrics
+                };
+
                 (metrics, cmap, base_name, None, false, 0, encoding, None)
             }
         } else {

--- a/crates/pdfplumber-parse/src/standard_fonts.rs
+++ b/crates/pdfplumber-parse/src/standard_fonts.rs
@@ -375,6 +375,45 @@ static ZAPF_DINGBATS: StandardFontData = StandardFontData {
     font_bbox: [-1, -143, 981, 820],
 };
 
+/// Build a 256-element width vector for a standard font, remapped for a target encoding.
+///
+/// The standard font widths are natively indexed by WinAnsiEncoding character codes.
+/// When a different encoding is active (e.g., StandardEncoding), the same byte code
+/// maps to a different glyph, requiring width remapping via Unicode character matching.
+///
+/// `target_decode` maps a byte code to the Unicode character under the target encoding.
+/// Returns `None` if `font_name` is not a standard font.
+pub fn build_remapped_widths(
+    font_name: &str,
+    target_decode: impl Fn(u8) -> Option<char>,
+) -> Option<Vec<f64>> {
+    let std_font = lookup(font_name)?;
+
+    // Build Unicode char → width from WinAnsi positions
+    let mut char_to_width = std::collections::HashMap::new();
+    for code in 0u16..256 {
+        if let Some(ch) = pdfplumber_core::StandardEncoding::WinAnsi.decode(code as u8) {
+            let w = std_font.widths[code as usize];
+            if w > 0 {
+                char_to_width.entry(ch).or_insert(w);
+            }
+        }
+    }
+
+    // Build widths for target encoding
+    let mut result = Vec::with_capacity(256);
+    for code in 0u16..256 {
+        if let Some(ch) = target_decode(code as u8) {
+            let w = char_to_width.get(&ch).copied().unwrap_or(0);
+            result.push(f64::from(w));
+        } else {
+            result.push(0.0);
+        }
+    }
+
+    Some(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -499,5 +538,91 @@ mod tests {
         let data = lookup("Helvetica").unwrap();
         assert_eq!(data.widths.len(), 256);
         assert_eq!(data.font_bbox.len(), 4);
+    }
+
+    // ========== US-182-2: Encoding-aware width remapping ==========
+
+    #[test]
+    fn remap_helvetica_standard_encoding_quoteright() {
+        // StandardEncoding code 0x27 = quoteright (U+2019)
+        // In WinAnsi, quoteright is at code 0x92 (146) with width 222
+        // Without remapping, code 0x27 gets quotesingle width 191 (wrong)
+        let widths = build_remapped_widths("Helvetica", |code| {
+            pdfplumber_core::StandardEncoding::Standard.decode(code)
+        })
+        .unwrap();
+        assert_eq!(
+            widths[0x27] as u16, 222,
+            "code 0x27 under StandardEncoding should be quoteright width 222, not quotesingle 191"
+        );
+    }
+
+    #[test]
+    fn remap_helvetica_standard_encoding_quoteleft() {
+        // StandardEncoding code 0x60 = quoteleft (U+2018)
+        // In WinAnsi, quoteleft is at code 0x91 (145) with width 222
+        // Without remapping, code 0x60 gets grave width 333 (wrong)
+        let widths = build_remapped_widths("Helvetica", |code| {
+            pdfplumber_core::StandardEncoding::Standard.decode(code)
+        })
+        .unwrap();
+        assert_eq!(
+            widths[0x60] as u16, 222,
+            "code 0x60 under StandardEncoding should be quoteleft width 222, not grave 333"
+        );
+    }
+
+    #[test]
+    fn remap_winansi_preserves_original_widths() {
+        // When target encoding is WinAnsi, widths should match the original table
+        let data = lookup("Helvetica").unwrap();
+        let widths = build_remapped_widths("Helvetica", |code| {
+            pdfplumber_core::StandardEncoding::WinAnsi.decode(code)
+        })
+        .unwrap();
+        assert_eq!(
+            widths[0x27] as u16, data.widths[0x27],
+            "WinAnsi remapping should preserve original widths"
+        );
+        assert_eq!(
+            widths[0x27] as u16, 191,
+            "code 0x27 under WinAnsi = quotesingle width 191"
+        );
+    }
+
+    #[test]
+    fn remap_shared_ascii_positions_unchanged() {
+        // ASCII letters/digits are the same in both encodings
+        let data = lookup("Helvetica").unwrap();
+        let widths = build_remapped_widths("Helvetica", |code| {
+            pdfplumber_core::StandardEncoding::Standard.decode(code)
+        })
+        .unwrap();
+        // 'A' (0x41) should be identical
+        assert_eq!(widths[0x41] as u16, data.widths[0x41]);
+        // space (0x20) should be identical
+        assert_eq!(widths[0x20] as u16, data.widths[0x20]);
+    }
+
+    #[test]
+    fn remap_unknown_font_returns_none() {
+        let result = build_remapped_widths("UnknownFont", |code| {
+            pdfplumber_core::StandardEncoding::Standard.decode(code)
+        });
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn remap_times_roman_standard_encoding_quoteright() {
+        // Same remapping test for Times-Roman
+        let widths = build_remapped_widths("Times-Roman", |code| {
+            pdfplumber_core::StandardEncoding::Standard.decode(code)
+        })
+        .unwrap();
+        // Times-Roman quoteright width = 333 (at WinAnsi code 0x92)
+        assert_eq!(
+            widths[0x27] as u16, 333,
+            "Times-Roman code 0x27 under StandardEncoding should be quoteright width"
+        );
     }
 }

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -33,7 +33,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "Key file: crates/pdfplumber-parse/src/standard_fonts.rs. The current width arrays are indexed by character code position assuming WinAnsiEncoding. A better approach: create a HashMap<&str, u16> mapping glyph name → width for each standard font, then look up by glyph name derived from the active encoding. The glyph names for standard fonts are well-defined in the PDF spec Appendix D."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -7,6 +7,7 @@ Started: 2026년  3월  1일 일요일 22시 19분 17초 KST
 - **Standard font identification**: `standard_fonts::lookup()` matches all 14 standard fonts; `is_standard_latin_font()` excludes Symbol/ZapfDingbats
 - **Font cache population**: `load_font_if_needed()` in interpreter.rs builds `CachedFont` with optional `encoding` field
 - **StandardEncoding table**: Already existed in `pdfplumber-core/src/encoding.rs` as `STANDARD_TABLE` — maps byte codes to Unicode (e.g., 0x27→U+2019 quoteright, 0x60→U+2018 quoteleft)
+- **Width remapping for non-WinAnsi encodings**: `standard_fonts::build_remapped_widths()` remaps standard font widths from WinAnsi indexing to any target encoding by building a Unicode char → width HashMap from WinAnsi positions, then rebuilding the array for the target encoding
 
 ---
 
@@ -22,4 +23,19 @@ Started: 2026년  3월  1일 일요일 22시 19분 17초 KST
   - The StandardEncoding table was already fully implemented in pdfplumber-core — the missing piece was just the fallback logic in the interpreter.
   - Symbol and ZapfDingbats must be excluded from StandardEncoding fallback since they have their own built-in encodings.
   - The `extract_font_encoding()` function returns `None` when no /Encoding entry exists — this is by design (early return with `?`), so the fallback must be applied at the call site.
+---
+
+## 2026-03-01 - US-182-2
+- **What was implemented**: Fixed standard font width lookup to use glyph names (via Unicode character matching) instead of encoding-dependent character codes. When a standard font uses StandardEncoding (no /Widths array), widths are now correctly remapped so each byte code gets the width of the glyph it represents under the active encoding.
+- **Files changed**:
+  - `crates/pdfplumber-parse/src/standard_fonts.rs` — Added `build_remapped_widths()` function that builds a correctly-indexed width array for any encoding by mapping Unicode chars between WinAnsi and target encoding. Added 6 unit tests.
+  - `crates/pdfplumber-parse/src/interpreter.rs` — In `load_font_if_needed()`, added width remapping after encoding determination: when a font has no /Widths and uses a non-WinAnsi encoding, the standard font widths are remapped via `build_remapped_widths()`.
+  - `scripts/ralph/prd.json` — Marked US-182-2 as passes: true.
+- **Dependencies added**: None
+- **Results**: All 24 accuracy benchmarks pass. No regression on any existing PDFs.
+- **Learnings for future iterations:**
+  - The standard font width tables in standard_fonts.rs are indexed by WinAnsiEncoding positions. When StandardEncoding is active, the same byte code refers to a different glyph (e.g., 0x27 = quotesingle in WinAnsi vs quoteright in Standard).
+  - The remapping approach uses Unicode as a proxy for glyph identity: build a HashMap<char, u16> from WinAnsi positions, then look up each target encoding position's Unicode char in the map.
+  - The remapping only applies when /Widths is absent (standard font fallback). PDFs with explicit /Widths arrays are unaffected since the PDF producer already set correct widths.
+  - `FontEncoding::decode(code)` returns the Unicode character for any code position, making it a convenient encoding-agnostic width remapping key.
 ---


### PR DESCRIPTION
## Summary
- Added `build_remapped_widths()` function to `standard_fonts.rs` that remaps standard font widths from WinAnsiEncoding indexing to any target encoding via Unicode character matching
- Integrated width remapping in `interpreter.rs` `load_font_if_needed()`: when a standard font has no `/Widths` array and uses a non-WinAnsi encoding (e.g., StandardEncoding), widths are correctly remapped so byte code 0x27 gets quoteright width (222) instead of quotesingle width (191)
- Added 6 unit tests covering StandardEncoding remapping, WinAnsi identity preservation, ASCII position invariance, Times-Roman cross-font validation, and unknown font handling

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (excluding pdfplumber-py which requires Python runtime)
- [x] All 24 accuracy benchmark tests pass with no regression
- [x] All 57 integration tests pass
- [x] StandardEncoding code 0x27 correctly maps to quoteright width 222 (was 191)
- [x] WinAnsiEncoding remapping preserves original widths (identity check)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)