### PR TITLE
feat: US-187-1 - Extract glyph widths from font descriptors and /Widths arrays

### DIFF
--- a/crates/pdfplumber/tests/cross_validation.rs
+++ b/crates/pdfplumber/tests/cross_validation.rs
@@ -1117,15 +1117,17 @@ cross_validate!(
     CHAR_THRESHOLD,
     WORD_THRESHOLD
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_python_issue_463,
     "issue-463-example.pdf",
-    "chars 89.4% — slightly below 95% threshold"
+    CHAR_THRESHOLD,
+    WORD_THRESHOLD
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_python_issue_53,
     "issue-53-example.pdf",
-    "chars 94.1%, words 92.1% — slightly below 95%"
+    CHAR_THRESHOLD,
+    WORD_THRESHOLD
 );
 cross_validate!(
     cv_python_issue_67,
@@ -1148,10 +1150,11 @@ cross_validate_ignored!(
     "issue-842-example.pdf",
     "chars 2.3% — font encoding gap"
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_python_issue_982,
     "issue-982-example.pdf",
-    "chars 85.4% — CIDFont pages below threshold"
+    CHAR_THRESHOLD,
+    WORD_THRESHOLD
 );
 cross_validate_ignored!(
     cv_python_issue_987,

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -18,7 +18,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "Key file: crates/pdfplumber-parse/src/interpreter.rs (font setup). /Widths is an array of widths for char codes from /FirstChar to /LastChar. The width for code c is Widths[c - FirstChar]. This should override standard font fallback widths. Check interpreter's resolve_char_width() or equivalent function."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -25,3 +25,17 @@
 # Ralph Progress Log - Issue #187: Improve font metrics precision for near-threshold PDFs
 Started: 2026년  3월  2일 월요일 02시 49분 02초 KST
 ---
+
+## 2026-03-02 - US-187-1
+- **What was implemented**: Promoted 3 cross-validation tests from `cross_validate_ignored!` to `cross_validate!` since prior work already brought them above the 95% threshold:
+  - issue-463-example.pdf: chars 100%, words 100% (target >= 92%)
+  - issue-53-example.pdf: chars 100%, words 100% (target >= 95%/93%)
+  - issue-982-example.pdf: chars 99.9%, words 99.5% (target >= 88%)
+- **Files changed**: `crates/pdfplumber/tests/cross_validation.rs`, `scripts/ralph/prd.json`, `scripts/ralph/progress.txt`
+- **Dependencies added**: None
+- **Learnings for future iterations:**
+  - Font /Widths array parsing was already implemented in `font_metrics.rs::extract_font_metrics()`, including /FirstChar, /LastChar, /FontDescriptor support
+  - Standard font fallback (14 Type1 fonts) and encoding remapping were also already complete
+  - The accuracy improvements that brought these PDFs above threshold likely came from prior PRs (encoding, CID font, standard font work)
+  - When a story's acceptance criteria are already met, the work is to verify and promote the tests from ignored to asserting
+---


### PR DESCRIPTION
## Summary

- Promote 3 cross-validation tests from `cross_validate_ignored!` to `cross_validate!` with standard thresholds
- issue-463-example.pdf: chars 100%, words 100% (target ≥ 92%)
- issue-53-example.pdf: chars 100%, words 100% (target ≥ 95%/93%)
- issue-982-example.pdf: chars 99.9%, words 99.5% (target ≥ 88%)
- Font /Widths array parsing already implemented by prior work; this PR verifies and asserts the improvements

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --test cross_validation` — 84 passed, 0 failed, 25 ignored
- [x] All 3 promoted tests pass with scores well above thresholds
- [x] No regressions on existing passing tests

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)