### PR TITLE
docs: add reference projects index

### DIFF
--- a/references/INDEX.md
+++ b/references/INDEX.md
@@ -1,0 +1,52 @@
+# Reference Projects Index
+
+Projects organized by domain. Read the specific file matching your current problem.
+
+## Direct Upstream
+
+| Project | Language | File | Use When |
+|---------|----------|------|----------|
+| [pdfplumber](https://github.com/jsvine/pdfplumber) | Python | [pdfplumber.md](pdfplumber.md) | API design, table detection pipeline, overall architecture |
+| [pdfminer.six](https://github.com/pdfminer/pdfminer.six) | Python | [pdfminer-six.md](pdfminer-six.md) | Text layout (LAParams), font metrics, CMap handling, char extraction |
+
+## Rust PDF Ecosystem
+
+| Project | Stars | File | Use When |
+|---------|-------|------|----------|
+| [lopdf](https://github.com/J-F-Liu/lopdf) | 2.1k | [lopdf.md](lopdf.md) | PDF object access, content stream decoding (current backend) |
+| [pdf-rs](https://github.com/pdf-rs/pdf) | 1.6k | [pdf-rs.md](pdf-rs.md) | Typed PDF object model, derive-macro patterns |
+| [pdf-extract](https://github.com/jrmuizel/pdf-extract) | 571 | [pdf-extract.md](pdf-extract.md) | CMap/CFF/Type1 parsing crate ecosystem on lopdf |
+| [pdf_oxide](https://github.com/yfedoseev/pdf_oxide) | 197 | [pdf-oxide.md](pdf-oxide.md) | Performance benchmarking, competitive analysis |
+
+## Font Parsing
+
+| Project | Language | File | Use When |
+|---------|----------|------|----------|
+| [ttf-parser](https://github.com/harfbuzz/ttf-parser) | Rust | [ttf-parser.md](ttf-parser.md) | TrueType hmtx/head/hhea/maxp table parsing |
+| [allsorts](https://github.com/yeslogic/allsorts) | Rust | [allsorts.md](allsorts.md) | CFF parsing (Top DICT, Private DICT, CharStrings) |
+| [Apache PDFBox](https://github.com/apache/pdfbox) | Java | [pdfbox.md](pdfbox.md) | Font class hierarchy, width resolution, CID fonts |
+| [pdf.js](https://github.com/mozilla/pdf.js) | JS | [pdfjs.md](pdfjs.md) | CFF width extraction, CMap binary format |
+| [adobe-cmap-parser](https://github.com/jrmuizel/adobe-cmap-parser) | Rust | [adobe-cmap-parser.md](adobe-cmap-parser.md) | CMap file parsing for CJK fonts |
+
+## Table Detection
+
+| Project | Language | File | Use When |
+|---------|----------|------|----------|
+| [Camelot](https://github.com/camelot-dev/camelot) | Python | [camelot.md](camelot.md) | Lattice (OpenCV morphology) and stream parser algorithms |
+| [tabula-java](https://github.com/tabulapdf/tabula-java) | Java | [tabula-java.md](tabula-java.md) | Ruling class design, spreadsheet cell extraction |
+
+## Text Layout & Reading Order
+
+| Project | Language | File | Use When |
+|---------|----------|------|----------|
+| [PdfPig](https://github.com/UglyToad/PdfPig) | C# | [pdfpig.md](pdfpig.md) | Multiple layout algorithms (XY Cut, Docstrum, Nearest Neighbour) |
+| [Poppler](https://gitlab.freedesktop.org/poppler/poppler) | C++ | [poppler.md](poppler.md) | Column detection, TextOutputDev coalesce algorithm |
+| [MuPDF](https://github.com/ArtifexSoftware/mupdf) | C | [mupdf.md](mupdf.md) | Stream-order text hierarchy (Block→Line→Span→Char) |
+
+## Utility Crates (Rust)
+
+| Crate | Use When |
+|-------|----------|
+| [unicode-bidi](https://github.com/servo/unicode-bidi) | BiDi text (UAX #9) |
+| [jieba-rs](https://github.com/messense/jieba-rs) | Chinese word segmentation |
+| [unicode-segmentation](https://crates.io/crates/unicode-segmentation) | Unicode word boundaries (UAX #29) |

--- a/references/adobe-cmap-parser.md
+++ b/references/adobe-cmap-parser.md
@@ -1,0 +1,23 @@
+# adobe-cmap-parser (Rust)
+
+- **URL:** https://github.com/jrmuizel/adobe-cmap-parser
+- **Stars:** 5 | **Downloads:** 690k+ on crates.io | **License:** MIT
+- **Status:** Maintained (last update Sep 2024)
+
+## What It Does
+
+Parses Adobe CMap files — character code to CID mappings.
+
+## Capabilities
+
+- Codespace range parsing
+- CID range mappings (`begincidrange`/`endcidrange`)
+- Individual CID mappings (`begincidchar`/`endcidchar`)
+- Handles Identity-H/V and CJK character collections
+
+## Relevance to pdfplumber-rs
+
+Small, focused crate for CMap parsing. Could be:
+1. Used directly as a dependency for CMap handling
+2. Referenced for correctness validation of pdfplumber-rs's own CMap parser (`cmap.rs`)
+3. Compared against for handling edge cases in CJK font support

--- a/references/allsorts.md
+++ b/references/allsorts.md
@@ -1,0 +1,31 @@
+# allsorts (Rust)
+
+- **URL:** https://github.com/yeslogic/allsorts
+- **Stars:** 793 | **License:** Apache-2.0 | **Latest:** 0.16.1
+- **Status:** Active
+
+## What It Does
+
+OpenType font parser, shaper, and subsetter. Parses glyf, CFF, CFF2, WOFF, WOFF2.
+
+## CFF Parsing (`src/cff/`)
+
+- CFF INDEX structures
+- Top DICT, Private DICT parsing
+- CharString interpreter (width extraction)
+- `nominalWidthX` + charstring width operand, or `defaultWidthX` if no width operand
+- CFF subsetting (eliminates unused operators)
+
+## Other Capabilities
+
+- Font shaping for complex scripts (Arabic, Indic, Thai)
+- TrueType table parsing (head, hhea, maxp, hmtx, cmap, etc.)
+- Font subsetting for PDF embedding
+
+## Origin
+
+Extracted from **Prince** (HTML/CSS to PDF tool) — well-tested with real PDF workflows.
+
+## Relevance to pdfplumber-rs
+
+**Strongest Rust reference for CFF parsing architecture.** Handles the same CFF structures pdfplumber-rs needs: Top DICT, Private DICT, nominalWidthX, defaultWidthX, CharStrings. The CharString parser implementation is particularly relevant for `cff.rs`.

--- a/references/camelot.md
+++ b/references/camelot.md
@@ -1,0 +1,33 @@
+# Camelot (Python)
+
+- **URL:** https://github.com/camelot-dev/camelot
+- **Stars:** ~3.6k | **License:** MIT | **Latest:** v1.0.9
+- **Status:** Actively maintained
+
+## Table Detection Algorithms
+
+### Lattice Parser (image-based)
+1. Convert PDF page to raster image (via pdfium)
+2. OpenCV morphological transforms (erosion + dilation) to isolate H/V line segments
+3. Detect intersections by pixel-AND of H and V line masks
+4. Compute table boundaries by pixel-OR of all line masks
+5. Scale detected coordinates from image space → PDF space
+6. Detect spanning cells using line segments and intersection points
+7. Remove detected edges, re-run to find additional tables
+
+### Stream Parser (text-based)
+1. Group words into text rows by y-axis overlap (via PDFMiner)
+2. Compute "text edges" — vertical/horizontal lines implied by text alignment
+3. Use text edges to guess table areas
+4. Guess column count within each area
+5. Remove identified edges, re-run until no new tables found
+
+## Key Design Decision
+
+Lattice converts to raster (loses precision, gains robustness against imperfect PDF lines). Stream stays in text-coordinate space.
+
+## Relevance to pdfplumber-rs
+
+- Lattice parser's morphological approach is an alternative to pdfplumber's line-intersection method
+- Stream parser's text-edge algorithm is a useful reference for the `"text"` edge strategy
+- Clean separation between lattice and stream detection approaches

--- a/references/lopdf.md
+++ b/references/lopdf.md
@@ -1,0 +1,31 @@
+# lopdf (Rust)
+
+- **URL:** https://github.com/J-F-Liu/lopdf
+- **Stars:** 2.1k | **License:** MIT | **MSRV:** 1.85
+- **Status:** Actively maintained (current backend for pdfplumber-rs)
+
+## What It Does
+
+Low-level PDF document manipulation: read, create, modify PDF files at the object level.
+
+## Architecture
+
+- `Document` contains numbered objects (`ObjectId`)
+- Pages in tree structure, accessed via `get_pages()`
+- Content streams decoded to `Vec<Operation>` (operator + operands)
+- Two parser backends: `nom_parser` (fast, recommended) and `pom_parser`
+- Handles xref tables, object resolution, stream decompression
+- `dictionary!` macro for building PDF structures
+
+## Key Capabilities for pdfplumber-rs
+
+- Raw content stream access (`Tj`, `TJ`, `Tm`, `Td` operators)
+- Object/stream decompression
+- PDF 1.5+ object streams and xref streams
+- Font dictionary access (but no font-program-level parsing)
+
+## Limitations
+
+- No text-level semantics — purely structural
+- No font metrics extraction from embedded font programs
+- No CMap parsing

--- a/references/mupdf.md
+++ b/references/mupdf.md
@@ -1,0 +1,36 @@
+# MuPDF (C)
+
+- **URL:** https://github.com/ArtifexSoftware/mupdf
+- **Stars:** 2.6k | **License:** AGPL-3.0
+- **Status:** Actively maintained (Artifex Software)
+
+## Text Hierarchy
+
+4-level structure built during sequential content stream parsing:
+
+**Block** (paragraph) → **Line** → **Span** (same font) → **Character**
+
+### Key Files
+- `source/fitz/stext-device.c` — Text extraction device
+- `include/mupdf/fitz/structured-text.h` — Structure definitions
+
+## Algorithm
+
+- Hierarchy built sequentially as content stream is parsed (not post-processing like pdfminer.six)
+- Heuristics consider: font size, font name, horizontal char distance, char width, vertical distances, writing direction/angle
+- Stream-order-dependent — produces different results from spatial-clustering approaches
+
+## Reading Order
+
+- `sort=True` reorders blocks top-left to bottom-right
+- Multi-column detection uses text background colors and H/V lines as column border hints
+
+## Characteristics
+
+- Very fast (used by Sumatrapdf, PyMuPDF)
+- Stream-order approach is simpler than spatial clustering but less robust for complex layouts
+- AGPL license restricts commercial use without Artifex license
+
+## Relevance to pdfplumber-rs
+
+Stream-order approach is an alternative to pdfminer.six's spatial clustering. The Block→Line→Span→Char hierarchy is a clean model. Worth comparing behavior on complex multi-column documents.

--- a/references/pdf-extract.md
+++ b/references/pdf-extract.md
@@ -1,0 +1,34 @@
+# pdf-extract (Rust)
+
+- **URL:** https://github.com/jrmuizel/pdf-extract
+- **Stars:** 571 | **License:** MIT | **Latest:** 0.10.0
+- **Status:** Active (282 commits, 17 contributors)
+
+## What It Does
+
+Text extraction from PDF files, built on lopdf.
+
+## Dependency Stack (maps sub-problems of PDF text extraction)
+
+- `lopdf 0.39` — PDF parsing backend
+- `adobe-cmap-parser` — CMap file parsing (CID mappings)
+- `cff-parser` — CFF/Type1C font parsing
+- `postscript` — PostScript font handling
+- `type1-encoding-parser` — Type1 font encoding
+- `encoding_rs` — Text encodings
+- `unicode-normalization` — Unicode NFC/NFD
+
+## Architecture
+
+- Layered on lopdf
+- Each font encoding type has a dedicated parser crate (clean modular design)
+- Simple API: `extract_text_from_mem()` returns plain text
+
+## Key Gap vs pdfplumber-rs
+
+Returns **flat text only** — no character positions, no bounding boxes, no glyph metrics, no table detection. This is exactly what pdfplumber-rs adds.
+
+## Relevance
+
+- The dependency crates (`adobe-cmap-parser`, `cff-parser`, etc.) could be reused or referenced for correctness validation
+- Shows the modular decomposition of font/encoding sub-problems in Rust

--- a/references/pdf-oxide.md
+++ b/references/pdf-oxide.md
@@ -1,0 +1,30 @@
+# pdf_oxide (Rust)
+
+- **URL:** https://github.com/yfedoseev/pdf_oxide
+- **Stars:** 197 | **License:** MIT/Apache-2.0
+- **Status:** Active (Jan 2025 commits)
+
+## What It Does
+
+Full-stack PDF processing: text extraction, image extraction, markdown conversion, PDF creation/editing. Bindings for Python, JS/WASM, CLI (22 commands), MCP server.
+
+## Performance Claims
+
+- 0.8ms mean per document
+- 5x faster than PyMuPDF, 15x than pypdf, 29x than pdfplumber
+- 100% pass rate on 3,830 real-world PDFs (veraPDF, pdf.js, DARPA SafeDocs)
+- 99.5% text parity vs PyMuPDF and pypdfium2
+
+## Architecture
+
+- Custom PDF parser (not built on lopdf or pdf-rs)
+- Character-level positioning data
+- Multi-language bindings: Python (PyPI), JS (WASM), CLI
+- Form fields, annotations, bookmarks
+
+## Relevance to pdfplumber-rs
+
+- **Most direct competitor** in the Rust PDF ecosystem
+- Provides character positions but **no table detection** (pdfplumber-rs's differentiator)
+- Benchmarking methodology (3,830 PDFs, text parity metrics) worth adopting
+- Performance numbers useful as competitive reference

--- a/references/pdf-rs.md
+++ b/references/pdf-rs.md
@@ -1,0 +1,28 @@
+# pdf-rs (Rust)
+
+- **URL:** https://github.com/pdf-rs/pdf
+- **Stars:** 1.6k | **License:** MIT
+- **Status:** Actively maintained (818 commits, 37 contributors)
+
+## What It Does
+
+Read, manipulate, write PDFs with a strongly typed object model.
+
+## Architecture
+
+- Workspace: `pdf` (core) + `pdf_derive` (proc macros) + `pdf_text` (text extraction)
+- PDF dictionaries auto-map to Rust structs via derive macros — catches structure errors at compile time
+- Resolver pattern for indirect object references
+- Typed enums for PDF value variants
+
+## Key Patterns Worth Studying
+
+- **Derive macros** for PDF object types reduce parsing boilerplate
+- **`pdf_text`** subcrate: CMap decoding, font encoding, Unicode mapping
+- **`pdf-rs/font`** (separate repo): glyf + CFF outlines, CMap formats, kerning
+
+## Relevance to pdfplumber-rs
+
+- Most "Rustic" approach to modeling PDF structures
+- If ever migrating from lopdf, pdf-rs offers a more type-safe foundation
+- The `pdf_text` CMap implementation is a useful reference

--- a/references/pdfbox.md
+++ b/references/pdfbox.md
@@ -1,0 +1,38 @@
+# Apache PDFBox (Java)
+
+- **URL:** https://github.com/apache/pdfbox
+- **Stars:** ~3k | **License:** Apache-2.0
+- **Status:** Actively maintained (Apache Foundation)
+
+## Font Architecture
+
+### Class Hierarchy
+- `PDFont` → `PDSimpleFont` (Type1, TrueType, Type3) and `PDType0Font` (composite)
+- Separate **FontBox** sub-library for low-level font parsing
+
+### Width Resolution Order
+1. PDF `/Widths` array
+2. Embedded font program (hmtx for TrueType, CharStrings for CFF)
+
+### TrueType (`fontbox/.../ttf/`)
+- `TTFParser`: parses mandatory tables `head`, `hhea`, `maxp`, `hmtx`
+- `getAdvanceWidth(gid)`, `getAdvanceHeight(gid)`
+
+### CFF (`fontbox/.../cff/`)
+- `CFFFont` (abstract) → `CFFCIDFont`, `CFFType1Font`
+- Top DICT, Private DICT, CharStrings
+- `getWidth(String name)` returns advance width from CharString data
+
+### CMap Support
+- Predefined Adobe character collections (Japan1, GB1, CNS1, Korea1)
+- CMap caching and Identity-H/V handling
+
+## Key Reference Files
+
+- `fontbox/src/main/java/org/apache/fontbox/ttf/TTFParser.java`
+- `fontbox/src/main/java/org/apache/fontbox/cff/`
+- `pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/`
+
+## Relevance to pdfplumber-rs
+
+Comprehensive Java implementation of font class hierarchy and width resolution. Useful reference for CID font handling and the Type0→CIDFont delegation pattern.

--- a/references/pdfjs.md
+++ b/references/pdfjs.md
@@ -1,0 +1,26 @@
+# pdf.js (JavaScript)
+
+- **URL:** https://github.com/mozilla/pdf.js
+- **Stars:** ~52.9k | **License:** Apache-2.0
+- **Status:** Very actively maintained (Mozilla)
+
+## Font Parsing
+
+### CFF (`src/core/cff_parser.js`)
+- CharString state machine extracts width per glyph
+- Width = `nominalWidthX + charstring_width_operand`, or `defaultWidthX` if no operand
+- Known bug: negative width differences from nominalWidthX historically mishandled ([#12541](https://github.com/mozilla/pdf.js/issues/12541))
+
+### CMap (`src/core/cmap.js`)
+- Predefined binary CMap (`.bcmap`) format for CJK
+- Has had issues with malformed CMap data in ToUnicode streams ([#4875](https://github.com/mozilla/pdf.js/issues/4875))
+
+### Fonts (`src/core/fonts.js`)
+- Font loading, type detection, metrics aggregation
+- Width comparison: calculates both PDF-declared and font-program widths, flags mismatches
+
+## Relevance to pdfplumber-rs
+
+- CFF width extraction logic is clearly documented in `cff_parser.js`
+- Width mismatch detection pattern (PDF vs font program) useful for debugging
+- Binary CMap format could be a future optimization for CJK loading speed

--- a/references/pdfminer-six.md
+++ b/references/pdfminer-six.md
@@ -1,0 +1,39 @@
+# pdfminer.six (Python)
+
+- **URL:** https://github.com/pdfminer/pdfminer.six
+- **Stars:** ~6.9k | **License:** MIT | **Latest:** 20260107
+- **Status:** Actively maintained
+
+## Text Layout Pipeline (`layout.py`)
+
+3-stage pipeline controlled by `LAParams`:
+
+### 1. Characters → Lines
+- `char_margin` (default 2.0): max horizontal distance (relative to char width) to group chars
+- `line_overlap` (default 0.5): min vertical overlap (relative to char height) to be on same line
+- Output: `LTTextLineHorizontal` / `LTTextLineVertical`
+
+### 2. Lines → Text Boxes
+- `line_margin` (default 0.5): max vertical distance between lines
+- Lines grouped via `Plane` spatial index; must match in height and alignment
+- Output: `LTTextBoxHorizontal` / `LTTextBoxVertical`
+
+### 3. Text Boxes → Reading Order
+- Hierarchical agglomerative clustering using "unused space" distance metric
+- `boxes_flow` (default 0.5, range -1.0 to +1.0): sort key formula:
+  `(1 - boxes_flow) * x0 - (1 + boxes_flow) * (y0 + y1)`
+
+## Font Metrics (`pdffont.py`, `cmapdb.py`)
+
+- Font types: Type1, TrueType, Type3, CID fonts
+- Width from `/Widths`, `/FirstChar`, `/LastChar` arrays
+- CID `/W` entries: `[start [w1 w2 ...]]` or `[start end w]`; `/DW2` for vertical
+- CMapDB caches CMaps by name; PDFResourceManager caches fonts by object ID
+- Descriptors: `/Ascent`, `/Descent`, `/FontBBox`
+
+## Relevance to pdfplumber-rs
+
+pdfplumber-rs must match pdfminer.six behavior for Python compatibility. Key files:
+- `layout.py` — LAParams pipeline (target behavior for text grouping)
+- `pdffont.py` — Font width extraction (target behavior for char bbox)
+- `cmapdb.py` — CMap loading and CID mapping

--- a/references/pdfpig.md
+++ b/references/pdfpig.md
@@ -1,0 +1,36 @@
+# PdfPig (C#)
+
+- **URL:** https://github.com/UglyToad/PdfPig
+- **Stars:** 2.4k | **License:** Apache-2.0
+- **Status:** Actively maintained
+- **Wiki:** https://github.com/UglyToad/PdfPig/wiki/Document-Layout-Analysis
+
+## Text Layout Algorithms (most diverse of any project)
+
+### Word Extraction: Nearest Neighbour
+- Connects each glyph's `EndBaseLine` to closest glyph's `StartBaseLine`
+- Manhattan distance (axis-aligned) or Euclidean (rotated text)
+- DFS groups connected glyphs into words
+- Handles LTR, RTL, and rotated text
+
+### Page Segmentation: Recursive XY Cut
+- Top-down: scan horizontally for vertical gaps, then vertically for horizontal gaps
+- Uses dominant font dimensions for gap thresholds
+- Good for single/multi-column layouts
+
+### Page Segmentation: Docstrum (Document Spectrum)
+- Bottom-up: nearest-neighbor analysis of word centroids
+- Estimates line spacing, constructs text lines, assembles blocks
+- Effective for complex layouts (L-shaped text, rotated paragraphs)
+
+### Reading Order: Unsupervised Detector
+- Allen's interval algebra with tolerance parameter
+- Establishes reading sequences from spatial relationships + rendering order
+
+## Companion Project
+
+[BobLd/DocumentLayoutAnalysis](https://github.com/BobLd/DocumentLayoutAnalysis) (631 stars) — additional layout analysis resources.
+
+## Relevance to pdfplumber-rs
+
+Best algorithmic diversity for layout analysis. XY Cut and Docstrum are well-documented alternatives to pdfminer.six's LAParams approach. Nearest Neighbour word extraction handles rotated/RTL text better.

--- a/references/pdfplumber.md
+++ b/references/pdfplumber.md
@@ -1,0 +1,34 @@
+# pdfplumber (Python)
+
+- **URL:** https://github.com/jsvine/pdfplumber
+- **Stars:** ~9.8k | **License:** MIT | **Latest:** v0.11.9 (2026-01-05)
+- **Status:** Actively maintained
+
+## Architecture
+
+Built on **pdfminer.six** (handles PDF parsing, font metrics, char extraction). pdfplumber adds spatial APIs and table detection on top.
+
+**Key source files:**
+- `pdf.py` — PDF container, open/close
+- `page.py` — Page API, crop, filter, `.chars`/`.lines`/`.rects`/`.curves`
+- `table.py` — `TableFinder` class (edge collection → snap → join → intersect → cells → tables)
+- `ctm.py` — Coordinate transform matrices
+- `utils/` — Geometry helpers, text algorithms, clustering
+
+## Table Detection Pipeline (`table.py`)
+
+1. Collect edges based on strategy: `"lines"`, `"lines_strict"`, `"text"`, `"explicit"`
+2. `snap_edges` — merge parallel lines within `snap_tolerance`
+3. `join_edges` — connect collinear segments within `join_tolerance`
+4. Find intersections within `intersection_tolerance`
+5. Construct granular rectangular cells from intersection vertices
+6. Group contiguous cells into tables
+
+**Configurable via `TableSettings`:** snap tolerances, edge strategies, `min_words_vertical`/`min_words_horizontal`, `edge_min_length`.
+
+## Key Design Decisions
+
+- Font metrics delegated entirely to pdfminer.six
+- Each page object carries full metadata (font, size, position, color)
+- Visual debugging via `.to_image()` — renders overlays for chars, lines, rects, table cells
+- No PDF parsing of its own — purely spatial analysis layer

--- a/references/poppler.md
+++ b/references/poppler.md
@@ -1,0 +1,31 @@
+# Poppler (C++)
+
+- **URL:** https://gitlab.freedesktop.org/poppler/poppler
+- **Stars:** N/A (GitLab) | **License:** GPL-2.0+
+- **Status:** Actively maintained (~20 years maturity)
+
+## Text Layout: `TextOutputDev.cc`
+
+### Characters → Words
+- Groups by font size similarity (`maxWordFontSizeDelta`)
+- Baseline alignment (`maxIntraLineDelta`)
+- Spacing thresholds (`minWordSpacing`, `maxWordSpacing`)
+
+### Words → Lines/Blocks (`coalesce()`)
+- Hardcoded constants for block font size delta, column spacing
+- `fixed_pitch` parameter: max word distance and min column spacing
+- Two modes: `physLayout` (preserve physical layout) and `rawOrder` (content stream order)
+
+### Column Detection
+- Heuristics follow columns and tables for reading order
+- Uses column spacing thresholds to identify column boundaries
+
+## Characteristics
+
+- Very mature (~20 years), widely used (Evince, Okular)
+- Constants largely hardcoded — less configurable than pdfminer.six
+- Strong column detection for multi-column documents
+
+## Relevance to pdfplumber-rs
+
+The `coalesce()` algorithm's approach to column separation is worth studying for multi-column PDF handling. The hardcoded constants represent decades of tuning on real-world documents.

--- a/references/tabula-java.md
+++ b/references/tabula-java.md
@@ -1,0 +1,39 @@
+# tabula-java (Java)
+
+- **URL:** https://github.com/tabulapdf/tabula-java
+- **Stars:** ~2k | **License:** MIT
+- **Status:** Maintained (powers Tabula GUI app)
+
+## Detection Algorithms
+
+### SpreadsheetDetectionAlgorithm (Lattice)
+- Finds tables using intersecting ruling lines
+- Merges ruling lines, finds intersection points, constructs cells
+
+### NurminenDetectionAlgorithm
+- Based on Anssi Nurminen's master's thesis on table detection
+- Text-block analysis + ruling-line heuristics to guess table regions
+- Delegates to SpreadsheetExtractionAlgorithm for cell extraction
+
+## Extraction Algorithms
+
+### SpreadsheetExtractionAlgorithm (Ruled tables)
+- `findCells()` takes H + V `Ruling` objects
+- Finds intersections via `Ruling.findIntersections()`
+- Builds cell grid from crossing points
+
+### BasicExtractionAlgorithm (Stream mode)
+- No ruling lines — groups text by proximity
+
+## Key Design: `Ruling` Class
+- First-class objects with merge and intersection methods
+- Clean OOP design for line manipulation
+
+## Key Reference Files
+- `src/main/java/technology/tabula/extractors/SpreadsheetExtractionAlgorithm.java`
+- `src/main/java/technology/tabula/detectors/NurminenDetectionAlgorithm.java`
+- `src/main/java/technology/tabula/Ruling.java`
+
+## Relevance to pdfplumber-rs
+
+The `Ruling` class design and `findCells()` method offer a well-structured Java implementation of lattice table detection, potentially cleaner to reference than Python code.

--- a/references/ttf-parser.md
+++ b/references/ttf-parser.md
@@ -1,0 +1,33 @@
+# ttf-parser (Rust)
+
+- **URL:** https://github.com/harfbuzz/ttf-parser
+- **Stars:** 753 | **License:** MIT/Apache-2.0 | **Latest:** 0.25.1
+- **Status:** Stable
+
+## What It Does
+
+Zero-allocation, zero-unsafe TrueType/OpenType/AAT parser. Parses 47+ table types.
+
+## Key Tables for pdfplumber-rs
+
+- **`hmtx`** (`src/tables/hmtx.rs`): `Metrics { advance, side_bearing }`. GIDs >= `num_h_metrics` reuse last advance width.
+- **`head`**: Units per em, bbox, flags
+- **`hhea`**: Number of h-metrics, ascender/descender
+- **`maxp`**: Number of glyphs
+- **`cmap`**: Character-to-glyph mapping
+- **CFF/CFF2**: Outline support
+
+## API Levels
+
+- **High-level:** `Face::glyph_hor_advance(glyph_id)` → advance width
+- **Low-level:** Direct table access for custom processing
+
+## Architecture
+
+- Many libraries built on top: rusttype, ab-glyph, fontdue
+- C API available for FFI usage
+- Pure Rust, no system dependencies
+
+## Relevance to pdfplumber-rs
+
+Best Rust reference for TrueType hmtx table parsing. Clean, safe implementation of glyph width extraction. The hmtx table structure (`num_h_metrics` entries of `{advance_width, lsb}` + extra `lsb` values) directly applies to `truetype.rs`.


### PR DESCRIPTION
## Summary
- Add `references/INDEX.md` with categorized index of 17 reference projects across 5 domains
- Add 16 individual detail files (under 50 lines each) covering: direct upstream (pdfplumber, pdfminer.six), Rust PDF ecosystem (lopdf, pdf-rs, pdf-extract, pdf_oxide), font parsing (ttf-parser, allsorts, PDFBox, pdf.js, adobe-cmap-parser), table detection (Camelot, tabula-java), and text layout (PdfPig, Poppler, MuPDF)
- Follows CLAUDE.md Reference Projects guidelines

## Test plan
- [ ] No runtime code changes — tests not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)