### PR TITLE
test: unignore 7 stale cross-validation fixtures now at 100%

### DIFF
--- a/crates/pdfplumber/tests/cross_validation.rs
+++ b/crates/pdfplumber/tests/cross_validation.rs
@@ -1093,15 +1093,17 @@ cross_validate!(
     CHAR_THRESHOLD,
     CHAR_THRESHOLD
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_python_issue_1147,
     "issue-1147-example.pdf",
-    "words 36.2% — word grouping algorithm gap"
+    CHAR_THRESHOLD,
+    CHAR_THRESHOLD
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_python_issue_1279,
     "issue-1279-example.pdf",
-    "chars 64.4% — complex layout extraction gap"
+    CHAR_THRESHOLD,
+    0.95 // words 98.3% — above threshold
 );
 cross_validate!(
     cv_python_issue_140,
@@ -1233,15 +1235,17 @@ cross_validate!(
 
 // ─── pdfplumber-python: ERROR tests (parse failures) ─────────────────────
 
-cross_validate_ignored!(
+cross_validate!(
     cv_python_annotations_rot180,
     "annotations-rotated-180.pdf",
-    "chars 100% but words 0% — rotation 180 word grouping gap"
+    CHAR_THRESHOLD,
+    CHAR_THRESHOLD
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_python_annotations_rot270,
     "annotations-rotated-270.pdf",
-    "chars 100% but words 0% — rotation 270 word grouping gap"
+    CHAR_THRESHOLD,
+    CHAR_THRESHOLD
 );
 cross_validate!(
     cv_python_annotations_rot90,
@@ -1255,7 +1259,12 @@ cross_validate!(
     CHAR_THRESHOLD,
     CHAR_THRESHOLD
 );
-cross_validate_ignored!(cv_python_issue_1181, "issue-1181.pdf", "PDF parse error");
+cross_validate!(
+    cv_python_issue_1181,
+    "issue-1181.pdf",
+    CHAR_THRESHOLD,
+    CHAR_THRESHOLD
+);
 cross_validate!(cv_python_issue_297, "issue-297-example.pdf", 1.0, 1.0);
 cross_validate_ignored!(cv_python_issue_848, "issue-848.pdf", "PDF parse error");
 cross_validate!(cv_python_pr_136, "pr-136-example.pdf", 0.15, 0.05);
@@ -1350,10 +1359,11 @@ cross_validate!(
     EXTERNAL_CHAR_THRESHOLD,
     EXTERNAL_WORD_THRESHOLD
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_pdfjs_vertical,
     "pdfjs/vertical.pdf",
-    "chars 0% — CJK vertical writing gap"
+    EXTERNAL_CHAR_THRESHOLD,
+    EXTERNAL_WORD_THRESHOLD
 );
 
 // ─── pdfbox: PASSING tests (chars/words >= 80%) ──────────────────────────
@@ -1385,10 +1395,11 @@ cross_validate!(
     EXTERNAL_CHAR_THRESHOLD,
     EXTERNAL_WORD_THRESHOLD
 );
-cross_validate_ignored!(
+cross_validate!(
     cv_pdfbox_3127_vfont,
     "pdfbox/pdfbox-3127-vfont-reduced.pdf",
-    "chars 0.3% — vertical font gap"
+    EXTERNAL_CHAR_THRESHOLD,
+    EXTERNAL_WORD_THRESHOLD
 );
 cross_validate!(
     cv_pdfbox_3833_japanese,


### PR DESCRIPTION
## Summary

7 `cross_validate_ignored!` entries were stale — the underlying issues they tracked have since been fixed and the fixtures now meet or exceed thresholds.

## Changes

Converted `cross_validate_ignored!` → `cross_validate!` for:

| Fixture | Chars | Words | Old reason |
|---|---|---|---|
| `pdfjs/vertical.pdf` | 100% | 100% | "CJK vertical writing gap" |
| `pdfbox/pdfbox-3127-vfont-reduced.pdf` | 100% | 100% | "vertical font gap" |
| `annotations-rotated-180.pdf` | 100% | 100% | "rotation 180 word grouping gap" |
| `annotations-rotated-270.pdf` | 100% | 100% | "rotation 270 word grouping gap" |
| `issue-1181.pdf` | 100% | 100% | "PDF parse error" |
| `issue-1147-example.pdf` | 100% | 100% | "word grouping algorithm gap" |
| `issue-1279-example.pdf` | 100% | 98.3% | "complex layout extraction gap" |

Remaining ignored: `hello_structure.pdf` (38.9% chars) and `issue-848.pdf` (41.1% words) — tracked in #220 and #221.

## Test plan
- [x] `cargo test -p pdfplumber --test cross_validation` — 107 passed, 0 failed, 2 ignored

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)