### PR TITLE
fix(rotation): correct text extraction for 90° and 270° rotated pages (#218)

### DIFF
--- a/crates/pdfplumber-core/src/layout.rs
+++ b/crates/pdfplumber-core/src/layout.rs
@@ -80,16 +80,37 @@ impl Default for TextOptions {
 
 /// Cluster words into text lines based on y-proximity.
 ///
-/// Words whose vertical midpoints are within `y_tolerance` of a line's
-/// vertical midpoint are grouped into the same line. Words within each
-/// line are sorted left-to-right.
+/// For horizontal text (Ltr/Rtl): words whose vertical midpoints are within
+/// `y_tolerance` are grouped into the same line, sorted left-to-right within
+/// each line, and lines are sorted top-to-bottom.
 ///
-/// Uses y-coordinate bucketing for O(n log n) performance instead of O(n²).
+/// For vertical text (Ttb/Btt, e.g. 90°/270° rotated pages): words whose
+/// horizontal midpoints are within `y_tolerance` (reused as x-tolerance) are
+/// grouped into the same column-line, sorted top-to-bottom within each column,
+/// and columns are sorted left-to-right (Ttb) or right-to-left (Btt).
+///
+/// Uses coordinate bucketing for O(n log n) performance instead of O(n²).
 pub fn cluster_words_into_lines(words: &[Word], y_tolerance: f64) -> Vec<TextLine> {
     if words.is_empty() {
         return Vec::new();
     }
 
+    // Detect dominant text direction: if majority are vertical, use x-clustering.
+    let vertical_count = words
+        .iter()
+        .filter(|w| matches!(w.direction, TextDirection::Ttb | TextDirection::Btt))
+        .count();
+    let is_vertical_page = vertical_count > words.len() / 2;
+
+    if is_vertical_page {
+        return cluster_vertical_words_into_lines(words, y_tolerance);
+    }
+
+    cluster_horizontal_words_into_lines(words, y_tolerance)
+}
+
+/// Cluster horizontal (Ltr/Rtl) words into lines by y-proximity.
+fn cluster_horizontal_words_into_lines(words: &[Word], y_tolerance: f64) -> Vec<TextLine> {
     let mut sorted: Vec<&Word> = words.iter().collect();
     sorted.sort_by(|a, b| {
         a.bbox
@@ -105,19 +126,12 @@ pub fn cluster_words_into_lines(words: &[Word], y_tolerance: f64) -> Vec<TextLin
     // bbox grows (union with a new word), its bucket registration is updated.
     let mut bucket_to_line: HashMap<i64, Vec<usize>> = HashMap::new();
 
-    let bucket_size = if y_tolerance > 0.0 {
-        y_tolerance
-    } else {
-        // For zero tolerance, use a very small bucket size
-        1e-9
-    };
+    let bucket_size = if y_tolerance > 0.0 { y_tolerance } else { 1e-9 };
 
     for word in sorted {
         let word_mid_y = (word.bbox.top + word.bbox.bottom) / 2.0;
         let word_bucket = (word_mid_y / bucket_size).floor() as i64;
 
-        // Check adjacent buckets (word_bucket - 1, word_bucket, word_bucket + 1)
-        // to find a matching line within y_tolerance
         let mut matched_line_idx: Option<usize> = None;
         'outer: for delta in [-1i64, 0, 1] {
             let check_bucket = word_bucket + delta;
@@ -134,15 +148,12 @@ pub fn cluster_words_into_lines(words: &[Word], y_tolerance: f64) -> Vec<TextLin
         }
 
         if let Some(idx) = matched_line_idx {
-            // Remove old bucket registration for this line
             let old_mid_y = (lines[idx].bbox.top + lines[idx].bbox.bottom) / 2.0;
             let old_bucket = (old_mid_y / bucket_size).floor() as i64;
 
-            // Update the line
             lines[idx].bbox = lines[idx].bbox.union(&word.bbox);
             lines[idx].words.push(word.clone());
 
-            // Re-register in the new bucket if mid_y changed
             let new_mid_y = (lines[idx].bbox.top + lines[idx].bbox.bottom) / 2.0;
             let new_bucket = (new_mid_y / bucket_size).floor() as i64;
             if new_bucket != old_bucket {
@@ -164,7 +175,6 @@ pub fn cluster_words_into_lines(words: &[Word], y_tolerance: f64) -> Vec<TextLin
     }
 
     // Sort words within each line by reading direction.
-    // For Rtl lines (e.g., 180° rotated text), sort right-to-left.
     for line in &mut lines {
         let rtl_count = line
             .words
@@ -172,18 +182,113 @@ pub fn cluster_words_into_lines(words: &[Word], y_tolerance: f64) -> Vec<TextLin
             .filter(|w| w.direction == TextDirection::Rtl)
             .count();
         if rtl_count > line.words.len() / 2 {
-            // Majority Rtl: sort by x0 descending (right-to-left)
             line.words
                 .sort_by(|a, b| b.bbox.x0.partial_cmp(&a.bbox.x0).unwrap());
         } else {
-            // Default Ltr: sort by x0 ascending (left-to-right)
             line.words
                 .sort_by(|a, b| a.bbox.x0.partial_cmp(&b.bbox.x0).unwrap());
         }
     }
 
-    // Sort lines top-to-bottom
     lines.sort_by(|a, b| a.bbox.top.partial_cmp(&b.bbox.top).unwrap());
+    lines
+}
+
+/// Cluster vertical (Ttb/Btt) words into lines by x-proximity.
+///
+/// On a 90°/270° rotated page each "line" of text appears as a vertical column
+/// of words that share the same x-range. We cluster by x-midpoint instead of
+/// y-midpoint, sort words within each column top-to-bottom, and sort columns
+/// left-to-right (Ttb/90°) or right-to-left (Btt/270°).
+fn cluster_vertical_words_into_lines(words: &[Word], x_tolerance: f64) -> Vec<TextLine> {
+    let mut sorted: Vec<&Word> = words.iter().collect();
+    // Sort by x-midpoint first, then top within the same x-band
+    sorted.sort_by(|a, b| {
+        let ax = (a.bbox.x0 + a.bbox.x1) / 2.0;
+        let bx = (b.bbox.x0 + b.bbox.x1) / 2.0;
+        ax.partial_cmp(&bx)
+            .unwrap()
+            .then(a.bbox.top.partial_cmp(&b.bbox.top).unwrap())
+    });
+
+    let mut lines: Vec<TextLine> = Vec::new();
+    let mut bucket_to_line: HashMap<i64, Vec<usize>> = HashMap::new();
+    let bucket_size = if x_tolerance > 0.0 { x_tolerance } else { 1e-9 };
+
+    for word in sorted {
+        let word_mid_x = (word.bbox.x0 + word.bbox.x1) / 2.0;
+        let word_bucket = (word_mid_x / bucket_size).floor() as i64;
+
+        let mut matched_line_idx: Option<usize> = None;
+        'outer: for delta in [-1i64, 0, 1] {
+            let check_bucket = word_bucket + delta;
+            if let Some(line_indices) = bucket_to_line.get(&check_bucket) {
+                for &line_idx in line_indices {
+                    let line = &lines[line_idx];
+                    let line_mid_x = (line.bbox.x0 + line.bbox.x1) / 2.0;
+                    if (word_mid_x - line_mid_x).abs() <= x_tolerance {
+                        matched_line_idx = Some(line_idx);
+                        break 'outer;
+                    }
+                }
+            }
+        }
+
+        if let Some(idx) = matched_line_idx {
+            let old_mid_x = (lines[idx].bbox.x0 + lines[idx].bbox.x1) / 2.0;
+            let old_bucket = (old_mid_x / bucket_size).floor() as i64;
+
+            lines[idx].bbox = lines[idx].bbox.union(&word.bbox);
+            lines[idx].words.push(word.clone());
+
+            let new_mid_x = (lines[idx].bbox.x0 + lines[idx].bbox.x1) / 2.0;
+            let new_bucket = (new_mid_x / bucket_size).floor() as i64;
+            if new_bucket != old_bucket {
+                if let Some(indices) = bucket_to_line.get_mut(&old_bucket) {
+                    indices.retain(|&i| i != idx);
+                }
+                bucket_to_line.entry(new_bucket).or_default().push(idx);
+            }
+        } else {
+            let new_idx = lines.len();
+            let mid_x = (word.bbox.x0 + word.bbox.x1) / 2.0;
+            let bucket = (mid_x / bucket_size).floor() as i64;
+            lines.push(TextLine {
+                words: vec![word.clone()],
+                bbox: word.bbox,
+            });
+            bucket_to_line.entry(bucket).or_default().push(new_idx);
+        }
+    }
+
+    let btt_count = words
+        .iter()
+        .filter(|w| w.direction == TextDirection::Btt)
+        .count();
+    let is_btt = btt_count > words.len() / 2;
+
+    // Sort words within each column by reading order:
+    // - Ttb (90°): top-to-bottom (ascending y)
+    // - Btt (270°): bottom-to-top (descending y) — reading goes up the page
+    for line in &mut lines {
+        if is_btt {
+            line.words
+                .sort_by(|a, b| b.bbox.top.partial_cmp(&a.bbox.top).unwrap());
+        } else {
+            line.words
+                .sort_by(|a, b| a.bbox.top.partial_cmp(&b.bbox.top).unwrap());
+        }
+    }
+
+    // Sort columns: Ttb (90°) left-to-right, Btt (270°) right-to-left.
+    // For a single-column Btt page the column order doesn't matter, but
+    // multi-column 270° pages read from the right column to the left.
+
+    if is_btt {
+        lines.sort_by(|a, b| b.bbox.x0.partial_cmp(&a.bbox.x0).unwrap());
+    } else {
+        lines.sort_by(|a, b| a.bbox.x0.partial_cmp(&b.bbox.x0).unwrap());
+    }
 
     lines
 }

--- a/crates/pdfplumber-core/src/words.rs
+++ b/crates/pdfplumber-core/src/words.rs
@@ -350,7 +350,20 @@ impl WordExtractor {
     }
 
     fn make_word(chars: &[Char], expand_ligatures: bool) -> Word {
-        let raw_text: String = chars.iter().map(|c| c.text.as_str()).collect();
+        // Btt and physical-Rtl chars are sorted in ascending spatial order during
+        // clustering, but their reading direction is opposite — reverse char order
+        // to restore reading order.
+        // Physical-Rtl detection: chars are at descending x positions (e.g. 180°
+        // rotation where TRM has negative x scaling).
+        let direction = chars[0].direction;
+        let is_physically_rtl = direction == TextDirection::Rtl
+            && chars.len() >= 2
+            && chars[0].bbox.x0 > chars[chars.len() - 1].bbox.x0;
+        let raw_text: String = if direction == TextDirection::Btt || is_physically_rtl {
+            chars.iter().rev().map(|c| c.text.as_str()).collect()
+        } else {
+            chars.iter().map(|c| c.text.as_str()).collect()
+        };
         let text = if expand_ligatures {
             expand_ligatures_in_text(&raw_text)
         } else {
@@ -362,7 +375,6 @@ impl WordExtractor {
             .reduce(|a, b| a.union(&b))
             .expect("make_word called with non-empty chars");
         let doctop = chars.iter().map(|c| c.doctop).fold(f64::INFINITY, f64::min);
-        let direction = chars[0].direction;
         Word {
             text,
             bbox,

--- a/crates/pdfplumber/tests/rotation_integration.rs
+++ b/crates/pdfplumber/tests/rotation_integration.rs
@@ -24,7 +24,6 @@ fn open_fixture(path: &Path) -> Pdf {
 // ==================== Text extraction on 90° rotated page ====================
 
 #[test]
-#[ignore = "vertical text (90° rotation) produces one word per line; extract_text joins with newlines instead of spaces"]
 fn rotated_90_extracts_correct_text() {
     let pdf = open_fixture(&generated("rotated_pages.pdf"));
     let page = pdf.page(1).unwrap();
@@ -135,7 +134,6 @@ fn rotated_180_page_dimensions_match_original() {
 // ==================== Text extraction on 270° rotated page ====================
 
 #[test]
-#[ignore = "vertical text (270° rotation) produces one word per line; extract_text joins with newlines instead of spaces"]
 fn rotated_270_extracts_correct_text() {
     let pdf = open_fixture(&generated("rotated_pages.pdf"));
     let page = pdf.page(3).unwrap();
@@ -195,8 +193,41 @@ fn mixed_rotation_document_has_correct_page_count() {
     assert_eq!(pdf.page_count(), 4);
 }
 
+/// All-pages test covering 0°, 90°, 180°, and 270° rotations in one document.
+/// 90° and 270° are fixed; 180° char-reversal is tracked in issue #XXX.
 #[test]
-#[ignore = "90° and 270° vertical text produces one word per line; extract_text joins with newlines instead of spaces"]
+fn mixed_rotation_0_and_90_and_270_extract_correctly() {
+    let pdf = open_fixture(&generated("rotated_pages.pdf"));
+    // Page 0: 0° — standard horizontal text
+    let page0 = pdf.page(0).unwrap();
+    let text0 = page0.extract_text(&TextOptions::default());
+    assert!(
+        text0.contains("This page has rotation = 0 degrees"),
+        "page 0 should contain expected text, got: {:?}",
+        text0.trim()
+    );
+
+    // Page 1: 90° — fixed by cluster_vertical_words_into_lines
+    let page1 = pdf.page(1).unwrap();
+    let text1 = page1.extract_text(&TextOptions::default());
+    assert!(
+        text1.contains("This page has rotation = 90 degrees"),
+        "page 1 should contain expected text, got: {:?}",
+        text1.trim()
+    );
+
+    // Page 3: 270° — fixed by cluster_vertical_words_into_lines + Btt char reversal
+    let page3 = pdf.page(3).unwrap();
+    let text3 = page3.extract_text(&TextOptions::default());
+    assert!(
+        text3.contains("This page has rotation = 270 degrees"),
+        "page 3 should contain expected text, got: {:?}",
+        text3.trim()
+    );
+}
+
+#[test]
+#[ignore = "180° char-reversal in extract_text: physically-LTR Rtl chars produce reversed words; tracked separately"]
 fn mixed_rotation_all_pages_extract_correctly() {
     let pdf = open_fixture(&generated("rotated_pages.pdf"));
     let expected_texts = [


### PR DESCRIPTION
## Problem

`extract_text()` on 90° and 270° rotated pages returned garbled text because:

1. **Wrong clustering axis**: `cluster_words_into_lines` grouped words by y-proximity, but on vertical pages words in the same "column" share an x-coordinate, not y.
2. **Reversed char order for 270° (Btt)**: Characters in Btt words were delivered in physical order (bottom→top), producing reversed text like `"seerged 09"` instead of `"90 degrees"`.

## Fix

**`crates/pdfplumber-core/src/words.rs` — `make_word`**
- Detect Btt direction and reverse char collection order so text reads naturally.
- Also detect physically-Rtl sequences (x0 decreasing) as a heuristic for future Rtl support.

**`crates/pdfplumber-core/src/layout.rs` — `cluster_words_into_lines`**
- Count Ttb/Btt words; if majority, dispatch to new `cluster_vertical_words_into_lines`.
- Vertical clustering groups by x-midpoint (columns), sorts Ttb words ascending-y and Btt words descending-y within each column, then orders columns left→right (Ttb) or right→left (Btt).

**`crates/pdfplumber/tests/rotation_integration.rs`**
- Removed `#[ignore]` from `rotated_90_extracts_correct_text` and `rotated_270_extracts_correct_text` — both now pass.
- Split `mixed_rotation_all_pages_extract_correctly` into:
  - `mixed_rotation_0_and_90_and_270_extract_correctly` — asserting, passes ✓
  - Original kept ignored with updated reason (180° char-reversal is a separate pre-existing issue)

## Test results

```
test result: ok. 29 passed; 0 failed; 1 ignored
```

The 1 ignored is the 180° mixed case, which has a separate root cause (physically-LTR Rtl chars) not addressed here.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)